### PR TITLE
fix(a11y): VoiceOver table navigation – row contains 3 stops

### DIFF
--- a/PiperApp/Resources/Localization/Localizable.xcstrings
+++ b/PiperApp/Resources/Localization/Localizable.xcstrings
@@ -1,7595 +1,7584 @@
 {
-  "sourceLanguage": "en",
-  "strings": {
-    "about_app": {
-      "comment": "A label for the \"About\" button in the main view.",
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حول التطبيق"
+  "sourceLanguage" : "en",
+  "strings" : {
+    "about_app" : {
+      "comment" : "A label for the \"About\" button in the main view.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حول التطبيق"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "অ্যাপ সম্পর্কে"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "অ্যাপ সম্পর্কে"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Über die App"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Über die App"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "About the App"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About the App"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Acerca de la aplicación"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acerca de la aplicación"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "À propos de l'application"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "À propos de l'application"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ऐप के बारे में"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ऐप के बारे में"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Az alkalmazásról"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Az alkalmazásról"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tentang Aplikasi"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tentang Aplikasi"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informazioni sull'app"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informazioni sull'app"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アプリについて"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリについて"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Over de app"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Over de app"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O aplikacji"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O aplikacji"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Om appen"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Om appen"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sobre o App"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sobre o App"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uygulama Hakkında"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uygulama Hakkında"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Про Додаток"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Про Додаток"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ایپ کے بارے میں"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایپ کے بارے میں"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "关于应用程序"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关于应用程序"
           }
         }
       }
     },
-    "app_help_line_1": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "قم بتثبيت صوت من قائمة **تحميل نموذج الصوت** لبدء استخدام التطبيق."
+    "app_help_line_1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قم بتثبيت صوت من قائمة **تحميل نموذج الصوت** لبدء استخدام التطبيق."
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "অ্যাপটি ব্যবহার শুরু করতে **ভয়েস মডেল ডাউনলোড করুন** মেনু থেকে একটি ভয়েস ইনস্টল করুন।"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "অ্যাপটি ব্যবহার শুরু করতে **ভয়েস মডেল ডাউনলোড করুন** মেনু থেকে একটি ভয়েস ইনস্টল করুন।"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installiere eine Stimme aus dem Menü **Sprachmodell herunterladen**, um die App zu nutzen."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installiere eine Stimme aus dem Menü **Sprachmodell herunterladen**, um die App zu nutzen."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Install a voice from **Download Voice Model** menu to start using the app."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a voice from **Download Voice Model** menu to start using the app."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instala una voz desde el menú **Descargar modelo de voz** para empezar a usar la aplicación."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instala una voz desde el menú **Descargar modelo de voz** para empezar a usar la aplicación."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installez une voix à partir du menu **Télécharger le modèle de voix** pour commencer à utiliser l'application."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installez une voix à partir du menu **Télécharger le modèle de voix** pour commencer à utiliser l'application."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ऐप का उपयोग शुरू करने के लिए **वॉयस मॉडल डाउनलोड करें** मेनू से आवाज़ इंस्टॉल करें।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ऐप का उपयोग शुरू करने के लिए **वॉयस मॉडल डाउनलोड करें** मेनू से आवाज़ इंस्टॉल करें।"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A használat megkezdéséhez telepítsen egy hangot a **Hangmodell letöltése** menüből."
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A használat megkezdéséhez telepítsen egy hangot a **Hangmodell letöltése** menüből."
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instal suara dari menu **Unduh Model Suara** untuk mulai menggunakan aplikasi."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instal suara dari menu **Unduh Model Suara** untuk mulai menggunakan aplikasi."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installa una voce dal menu **Scarica modello vocale** per iniziare a usare l'app."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installa una voce dal menu **Scarica modello vocale** per iniziare a usare l'app."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アプリの使用を開始するには、**音声モデルをダウンロード** メニューから音声をインストールしてください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリの使用を開始するには、**音声モデルをダウンロード** メニューから音声をインストールしてください。"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installeer een stem uit het menu **Download spraakmodel** om de app te gaan gebruiken."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installeer een stem uit het menu **Download spraakmodel** om de app te gaan gebruiken."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zainstaluj głos z menu **Pobierz model głosu**, aby rozpocząć korzystanie z aplikacji."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zainstaluj głos z menu **Pobierz model głosu**, aby rozpocząć korzystanie z aplikacji."
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installera en röst från menyn **Ladda ner röstmodell** för att börja använda appen."
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installera en röst från menyn **Ladda ner röstmodell** för att börja använda appen."
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instale uma voz do menu **Baixar Modelo de Voz** para começar a usar o app."
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instale uma voz do menu **Baixar Modelo de Voz** para começar a usar o app."
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uygulamayı kullanmaya başlamak için **Ses Modelini İndir** menüsünden bir ses yükleyin."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uygulamayı kullanmaya başlamak için **Ses Modelini İndir** menüsünden bir ses yükleyin."
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Встановіть голос за допомогою **Завантажити голосову модель**, щоб почати користуватися застосунком."
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Встановіть голос за допомогою **Завантажити голосову модель**, щоб почати користуватися застосунком."
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ایپ کا استعمال شروع کرنے کے لیے **ڈاؤن لوڈ وائس ماڈل** مینو سے آواز انسٹال کریں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایپ کا استعمال شروع کرنے کے لیے **ڈاؤن لوڈ وائس ماڈل** مینو سے آواز انسٹال کریں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "从 **Download Voice Model** 菜单安装语音以开始使用应用程序。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从 **Download Voice Model** 菜单安装语音以开始使用应用程序。"
           }
         }
       }
     },
-    "app_help_line_2_ios": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "انتقل إلى **الإعدادات ← تسهيلات الاستخدام ← VoiceOver ← النطق**."
+    "app_help_line_2_ios" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انتقل إلى **الإعدادات ← تسهيلات الاستخدام ← VoiceOver ← النطق**."
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**সেটিংস → অ্যাক্সেসিবিলিটি → ভয়েসওভার → স্পিচ**-এ যান।"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**সেটিংস → অ্যাক্সেসিবিলিটি → ভয়েসওভার → স্পিচ**-এ যান।"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gehe zu **Einstellungen → Bedienungshilfen → VoiceOver → Sprache**."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gehe zu **Einstellungen → Bedienungshilfen → VoiceOver → Sprache**."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Go to **Settings → Accessibility → VoiceOver → Speech**."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Go to **Settings → Accessibility → VoiceOver → Speech**."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ve a **Ajustes → Accesibilidad → VoiceOver → Voz**."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ve a **Ajustes → Accesibilidad → VoiceOver → Voz**."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Allez dans **Réglages → Accessibilité → VoiceOver → Parole**."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allez dans **Réglages → Accessibilité → VoiceOver → Parole**."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**सेटिंग्स → एक्सेसिबिलिटी → वॉयसओवर → स्पीच** पर जाएं।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**सेटिंग्स → एक्सेसिबिलिटी → वॉयसओवर → स्पीच** पर जाएं।"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lépjen a **Beállítások → Kisegítő lehetőségek → VoiceOver → Beszéd** menüpontba."
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lépjen a **Beállítások → Kisegítő lehetőségek → VoiceOver → Beszéd** menüpontba."
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buka **Pengaturan → Aksesibilitas → VoiceOver → Ucapan**."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buka **Pengaturan → Aksesibilitas → VoiceOver → Ucapan**."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vai su **Impostazioni → Accessibilità → VoiceOver → Voce**."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vai su **Impostazioni → Accessibilità → VoiceOver → Voce**."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**設定 → アクセシビリティ → VoiceOver → 読み上げ** に移動します。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**設定 → アクセシビリティ → VoiceOver → 読み上げ** に移動します。"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ga naar **Instellingen → Toegankelijkheid → VoiceOver → Spraak**."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ga naar **Instellingen → Toegankelijkheid → VoiceOver → Spraak**."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Przejdź do **Ustawienia → Dostępność → VoiceOver → Mowa**."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przejdź do **Ustawienia → Dostępność → VoiceOver → Mowa**."
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gå till **Inställningar → Hjälpmedel → VoiceOver → Tal**."
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gå till **Inställningar → Hjälpmedel → VoiceOver → Tal**."
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vá em **Ajustes → Acessibilidade → VoiceOver → Fala**."
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vá em **Ajustes → Acessibilidade → VoiceOver → Fala**."
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Ayarlar → Erişilebilirlik → VoiceOver → Konuşma** bölümüne gidin."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Ayarlar → Erişilebilirlik → VoiceOver → Konuşma** bölümüne gidin."
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Перейдіть до **Налаштування → Доступність → VoiceOver → Мова**."
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перейдіть до **Налаштування → Доступність → VoiceOver → Мова**."
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**ترتیبات → ایکسیسبیلٹی → وائس اوور → اسپیچ** پر جائیں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**ترتیبات → ایکسیسبیلٹی → وائس اوور → اسپیچ** پر جائیں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "转到 **设置 → 辅助功能 → VoiceOver → 语音**。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "转到 **设置 → 辅助功能 → VoiceOver → 语音**。"
           }
         }
       }
     },
-    "app_help_line_2_macos": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "افتح **أداة VoiceOver ← النطق**."
+    "app_help_line_2_macos" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "افتح **أداة VoiceOver ← النطق**."
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**VoiceOver Utility → Speech** খুলুন।"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**VoiceOver Utility → Speech** খুলুন।"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Öffne **VoiceOver-Dienstprogramm → Sprache**."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Öffne **VoiceOver-Dienstprogramm → Sprache**."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open **VoiceOver Utility → Speech**."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open **VoiceOver Utility → Speech**."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abre **Utilidad VoiceOver → Voz**."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abre **Utilidad VoiceOver → Voz**."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ouvrez **Utilitaire VoiceOver → Parole**."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrez **Utilitaire VoiceOver → Parole**."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**VoiceOver Utility → Speech** खोलें।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**VoiceOver Utility → Speech** खोलें।"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nyissa meg a **VoiceOver segédprogram → Beszéd** menüpontot."
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nyissa meg a **VoiceOver segédprogram → Beszéd** menüpontot."
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buka **Utilitas VoiceOver → Ucapan**."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buka **Utilitas VoiceOver → Ucapan**."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apri **Utility VoiceOver → Voce**."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apri **Utility VoiceOver → Voce**."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**VoiceOver ユーティリティ → 読み上げ** を開きます。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**VoiceOver ユーティリティ → 読み上げ** を開きます。"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open **VoiceOver-hulpprogramma → Spraak**."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open **VoiceOver-hulpprogramma → Spraak**."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otwórz **VoiceOver Utility → Mowa**."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otwórz **VoiceOver Utility → Mowa**."
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Öppna **VoiceOver-verktyg → Tal**."
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Öppna **VoiceOver-verktyg → Tal**."
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abra **Utilitário VoiceOver → Fala**."
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abra **Utilitário VoiceOver → Fala**."
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**VoiceOver Yardımcı Programı → Konuşma**'yı açın."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**VoiceOver Yardımcı Programı → Konuşma**'yı açın."
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Відкрийте **VoiceOver Utility → Мова**."
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відкрийте **VoiceOver Utility → Мова**."
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**VoiceOver Utility** → **Speech** کھولیں"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**VoiceOver Utility** → **Speech** کھولیں"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "打开 **VoiceOver 实用程序 → 语音**。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开 **VoiceOver 实用程序 → 语音**。"
           }
         }
       }
     },
-    "app_help_line_3_ios": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اضغط على **إضافة صوت الدوار**، وابحث عن الصوت الذي قمت بتثبيته تحت **Piper**، وقم باختياره."
+    "app_help_line_3_ios" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اضغط على **إضافة صوت الدوار**، وابحث عن الصوت الذي قمت بتثبيته تحت **Piper**، وقم باختياره."
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Add Rotor Voice**-এ ট্যাপ করুন, **Piper**-এর অধীনে আপনার ইনস্টল করা ভয়েসটি খুঁজুন এবং এটি নির্বাচন করুন।"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Add Rotor Voice**-এ ট্যাপ করুন, **Piper**-এর অধীনে আপনার ইনস্টল করা ভয়েসটি খুঁজুন এবং এটি নির্বাচন করুন।"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tippe auf **Rotor-Stimme hinzufügen**, suche die installierte Stimme unter **Piper** und wähle sie aus."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tippe auf **Rotor-Stimme hinzufügen**, suche die installierte Stimme unter **Piper** und wähle sie aus."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap **Add Rotor Voice**, find the voice you installed under **Piper**, and select it."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap **Add Rotor Voice**, find the voice you installed under **Piper**, and select it."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toca **Añadir voz al rotor**, busca la voz que instalaste en **Piper** y selecciónala."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca **Añadir voz al rotor**, busca la voz que instalaste en **Piper** y selecciónala."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Appuyez sur **Ajouter une voix au rotor**, trouvez la voix installée sous **Piper** et sélectionnez-la."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appuyez sur **Ajouter une voix au rotor**, trouvez la voix installée sous **Piper** et sélectionnez-la."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Add Rotor Voice** पर टैप करें, **Piper** के तहत आपके द्वारा इंस्टॉल की गई आवाज़ ढूंढें और उसे चुनें।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Add Rotor Voice** पर टैप करें, **Piper** के तहत आपके द्वारा इंस्टॉल की गई आवाज़ ढूंढें और उसे चुनें।"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Koppintson a **Rotorhang hozzáadása** elemre, keresse meg a telepített hangot a **Piper** alatt, és válassza ki."
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koppintson a **Rotorhang hozzáadása** elemre, keresse meg a telepített hangot a **Piper** alatt, és válassza ki."
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ketuk **Tambah Suara Rotor**, temukan suara yang Anda instal di bawah **Piper**, lalu pilih."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ketuk **Tambah Suara Rotor**, temukan suara yang Anda instal di bawah **Piper**, lalu pilih."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tocca **Aggiungi voce rotore**, trova la voce installata sotto **Piper** e selezionala."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tocca **Aggiungi voce rotore**, trova la voce installata sotto **Piper** e selezionala."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**ローターの音声を追加** をタップし、**Piper** の下にあるインストールした音声を見つけて選択します。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**ローターの音声を追加** をタップし、**Piper** の下にあるインストールした音声を見つけて選択します。"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tik op **Voeg rotor-stem toe**, zoek de stem die je hebt geïnstalleerd onder **Piper** en selecteer deze."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tik op **Voeg rotor-stem toe**, zoek de stem die je hebt geïnstalleerd onder **Piper** en selecteer deze."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stuknij **Dodaj głos rotora**, znajdź głos zainstalowany w **Piper** i wybierz go."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stuknij **Dodaj głos rotora**, znajdź głos zainstalowany w **Piper** i wybierz go."
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tryck på **Lägg till rotor-röst**, leta reda på rösten du installerade under **Piper** och välj den."
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tryck på **Lägg till rotor-röst**, leta reda på rösten du installerade under **Piper** och välj den."
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toque em **Adicionar Voz do Rotor**, encontre a voz instalada sob **Piper** e selecione-a."
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toque em **Adicionar Voz do Rotor**, encontre a voz instalada sob **Piper** e selecione-a."
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Rotor Sesini Ekle**'ye dokunun, yüklediğiniz sesi **Piper** altında bulun ve seçin."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Rotor Sesini Ekle**'ye dokunun, yüklediğiniz sesi **Piper** altında bulun ve seçin."
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Натисніть **Додати голос ротора**, знайдіть встановлений голос у розділі **Piper** та виберіть його."
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Натисніть **Додати голос ротора**, знайдіть встановлений голос у розділі **Piper** та виберіть його."
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Add Rotor Voice** پر ٹیپ کریں، **Piper** کے نیچے اپنی انسٹال کردہ آواز تلاش کریں، اور اسے منتخب کریں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Add Rotor Voice** پر ٹیپ کریں، **Piper** کے نیچے اپنی انسٹال کردہ آواز تلاش کریں، اور اسے منتخب کریں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击 **添加 Rotor Voice**，找到您在 **Piper** 下安装的语音，并选择它。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击 **添加 Rotor Voice**，找到您在 **Piper** 下安装的语音，并选择它。"
           }
         }
       }
     },
-    "app_help_line_3_macos": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "انقر على **إضافة**، ثم اختر الصوت المثبت."
+    "app_help_line_3_macos" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انقر على **إضافة**، ثم اختر الصوت المثبت."
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Add** এ ক্লিক করুন, তারপর ইনস্টল করা ভয়েসটি নির্বাচন করুন।"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Add** এ ক্লিক করুন, তারপর ইনস্টল করা ভয়েসটি নির্বাচন করুন।"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klicke auf **Hinzufügen** und wähle die installierte Stimme aus."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klicke auf **Hinzufügen** und wähle die installierte Stimme aus."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Click **Add**, then select the installed voice."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Click **Add**, then select the installed voice."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haz clic en **Añadir** y selecciona la voz instalada."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haz clic en **Añadir** y selecciona la voz instalada."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cliquez sur **Ajouter**, puis sélectionnez la voix installée."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cliquez sur **Ajouter**, puis sélectionnez la voix installée."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**जोड़ें** पर क्लिक करें, फिर इंस्टॉल की गई आवाज़ चुनें।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**जोड़ें** पर क्लिक करें, फिर इंस्टॉल की गई आवाज़ चुनें।"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kattintson a **Hozzáadás** gombra, majd válassza ki a telepített hangot."
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kattintson a **Hozzáadás** gombra, majd válassza ki a telepített hangot."
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klik **Tambah**, lalu pilih suara yang terinstal."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klik **Tambah**, lalu pilih suara yang terinstal."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fai clic su **Aggiungi**, quindi seleziona la voce installata."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fai clic su **Aggiungi**, quindi seleziona la voce installata."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**追加** をクリックし、インストールされた音声を選択します。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**追加** をクリックし、インストールされた音声を選択します。"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klik op **Voeg toe** en selecteer vervolgens de geïnstalleerde stem."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klik op **Voeg toe** en selecteer vervolgens de geïnstalleerde stem."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kliknij **Dodaj**, a następnie wybierz zainstalowany głos."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kliknij **Dodaj**, a następnie wybierz zainstalowany głos."
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klicka på **Lägg till** och välj sedan den installerade rösten."
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klicka på **Lägg till** och välj sedan den installerade rösten."
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clique em **Adicionar** e selecione a voz instalada."
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clique em **Adicionar** e selecione a voz instalada."
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Ekle**'ye tıklayın, ardından yüklü sesi seçin."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Ekle**'ye tıklayın, ardından yüklü sesi seçin."
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Клацніть **Додати**, потім виберіть встановлений голос."
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Клацніть **Додати**, потім виберіть встановлений голос."
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Add** پر کلک کریں، پھر انسٹال شدہ آواز کو منتخب کریں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Add** پر کلک کریں، پھر انسٹال شدہ آواز کو منتخب کریں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击 **添加**，然后选择已安装的语音。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击 **添加**，然后选择已安装的语音。"
           }
         }
       }
     },
-    "app_help_line_4": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "استخدم **البحث** إذا لم يظهر الصوت في القائمة."
+    "app_help_line_4" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "استخدم **البحث** إذا لم يظهر الصوت في القائمة."
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ভয়েসটি তালিকায় না থাকলে **Search** ব্যবহার করুন।"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ভয়েসটি তালিকায় না থাকলে **Search** ব্যবহার করুন।"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nutze die **Suche**, falls die Stimme nicht in der Liste erscheint."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nutze die **Suche**, falls die Stimme nicht in der Liste erscheint."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use **Search** if the voice does not appear in the list."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use **Search** if the voice does not appear in the list."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usa **Buscar** si la voz no aparece en la lista."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usa **Buscar** si la voz no aparece en la lista."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Utilisez la **Recherche** si la voix n'apparaît pas dans la liste."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilisez la **Recherche** si la voix n'apparaît pas dans la liste."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "यदि आवाज़ सूची में दिखाई नहीं देती है तो **खोज** का उपयोग करें।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "यदि आवाज़ सूची में दिखाई नहीं देती है तो **खोज** का उपयोग करें।"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Használja a **Keresés** funkciót, ha a hang nem jelenik meg a listában."
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Használja a **Keresés** funkciót, ha a hang nem jelenik meg a listában."
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gunakan **Cari** jika suara tidak muncul dalam daftar."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gunakan **Cari** jika suara tidak muncul dalam daftar."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usa la **Ricerca** se la voce non appare nell'elenco."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usa la **Ricerca** se la voce non appare nell'elenco."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リストに音声が表示されない場合は、**検索** を使用してください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リストに音声が表示されない場合は、**検索** を使用してください。"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gebruik **Zoek** als de stem niet in de lijst verschijnt."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gebruik **Zoek** als de stem niet in de lijst verschijnt."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Użyj **Szukaj**, jeśli głos nie pojawia się na liście."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Użyj **Szukaj**, jeśli głos nie pojawia się na liście."
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Använd **Sök** om rösten inte visas i listan."
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Använd **Sök** om rösten inte visas i listan."
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use a **Busca** se a voz não aparecer na lista."
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use a **Busca** se a voz não aparecer na lista."
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ses listede görünmüyorsa **Ara**'yı kullanın."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ses listede görünmüyorsa **Ara**'yı kullanın."
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Використайте **Пошук**, якщо голос не відображається у списку."
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Використайте **Пошук**, якщо голос не відображається у списку."
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اگر آواز فہرست میں ظاہر نہ ہو تو **Search** کا استعمال کریں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اگر آواز فہرست میں ظاہر نہ ہو تو **Search** کا استعمال کریں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "如果语音没有出现在列表中，请使用 **搜索**。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果语音没有出现在列表中，请使用 **搜索**。"
           }
         }
       }
     },
-    "app_help_line_5": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يمكن تثبيت أصوات مخصصة باستخدام **استيراد نموذج من الملفات** عن طريق اختيار نموذج `.onnx` وتكوين `.json` الخاص به."
+    "app_help_line_5" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يمكن تثبيت أصوات مخصصة باستخدام **استيراد نموذج من الملفات** عن طريق اختيار نموذج `.onnx` وتكوين `.json` الخاص به."
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "একটি `.onnx` মডেল এবং এর `.json` কনফিগারেশন নির্বাচন করে **Import Model from Files** ব্যবহার করে কাস্টম ভয়েস ইনস্টল করা যেতে পারে।"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "একটি `.onnx` মডেল এবং এর `.json` কনফিগারেশন নির্বাচন করে **Import Model from Files** ব্যবহার করে কাস্টম ভয়েস ইনস্টল করা যেতে পারে।"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eigene Stimmen können über **Modell aus Dateien importieren** installiert werden, indem ein `.onnx`-Modell und die zugehörige `.json`-Konfiguration ausgewählt werden."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eigene Stimmen können über **Modell aus Dateien importieren** installiert werden, indem ein `.onnx`-Modell und die zugehörige `.json`-Konfiguration ausgewählt werden."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Custom voices can be installed using **Import Model from Files** by selecting a `.onnx` model and its `.json` configuration."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom voices can be installed using **Import Model from Files** by selecting a `.onnx` model and its `.json` configuration."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se pueden instalar voces personalizadas usando **Importar modelo desde archivos** seleccionando un modelo `.onnx` y su configuración `.json`."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se pueden instalar voces personalizadas usando **Importar modelo desde archivos** seleccionando un modelo `.onnx` y su configuración `.json`."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Des voix personnalisées peuvent être installées via **Importer le modèle depuis les fichiers** en sélectionnant un modèle `.onnx` et sa configuration `.json`."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Des voix personnalisées peuvent être installées via **Importer le modèle depuis les fichiers** en sélectionnant un modèle `.onnx` et sa configuration `.json`."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कस्टम आवाज़ें **फ़ाइलों से मॉडल आयात करें** का उपयोग करके एक `.onnx` मॉडल और उसके `.json` कॉन्फ़िगरेशन का चयन करके इंस्टॉल की जा सकती हैं।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कस्टम आवाज़ें **फ़ाइलों से मॉडल आयात करें** का उपयोग करके एक `.onnx` मॉडल और उसके `.json` कॉन्फ़िगरेशन का चयन करके इंस्टॉल की जा सकती हैं।"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Egyéni hangok telepíthetők a **Modell importálása fájlokból** opcióval, egy `.onnx` modell és a hozzá tartozó `.json` konfiguráció kiválasztásával."
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Egyéni hangok telepíthetők a **Modell importálása fájlokból** opcióval, egy `.onnx` modell és a hozzá tartozó `.json` konfiguráció kiválasztásával."
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Suara kustom dapat diinstal menggunakan **Impor Model dari Berkas** dengan memilih model `.onnx` dan konfigurasi `.json`-nya."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suara kustom dapat diinstal menggunakan **Impor Model dari Berkas** dengan memilih model `.onnx` dan konfigurasi `.json`-nya."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Le voci personalizzate possono essere installate utilizzando **Importa modello da file** selezionando un modello `.onnx` e la sua configurazione `.json`."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le voci personalizzate possono essere installate utilizzando **Importa modello da file** selezionando un modello `.onnx` e la sua configurazione `.json`."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カスタム音声は、`.onnx` モデルとその `.json` 設定を選択して、**ファイルからモデルをインポート** を使用してインストールできます。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタム音声は、`.onnx` モデルとその `.json` 設定を選択して、**ファイルからモデルをインポート** を使用してインストールできます。"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aangepaste stemmen kunnen worden geïnstalleerd met **Importeer model uit bestanden** door een `.onnx`-model en de bijbehorende `.json`-configuratie te selecteren."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aangepaste stemmen kunnen worden geïnstalleerd met **Importeer model uit bestanden** door een `.onnx`-model en de bijbehorende `.json`-configuratie te selecteren."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Własne głosy można zainstalować za pomocą **Importuj model z plików**, wybierając model `.onnx` i jego konfigurację `.json`."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Własne głosy można zainstalować za pomocą **Importuj model z plików**, wybierając model `.onnx` i jego konfigurację `.json`."
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anpassade röster kan installeras via **Importera modell från filer** genom att välja en `.onnx`-modell och dess `.json`-konfiguration."
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anpassade röster kan installeras via **Importera modell från filer** genom att välja en `.onnx`-modell och dess `.json`-konfiguration."
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vozes personalizadas podem ser instaladas usando **Importar Modelo de Arquivos** selecionando um modelo `.onnx` e sua configuração `.json`."
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vozes personalizadas podem ser instaladas usando **Importar Modelo de Arquivos** selecionando um modelo `.onnx` e sua configuração `.json`."
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Özel sesler, bir `.onnx` modeli ve `.json` yapılandırmasını seçerek **Dosyalardan Model İçe Aktar** ile yüklenebilir."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Özel sesler, bir `.onnx` modeli ve `.json` yapılandırmasını seçerek **Dosyalardan Model İçe Aktar** ile yüklenebilir."
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Користувальницькі голоси можуть бути встановлені за допомогою **Імпортувати з файлів**, обравши модель `.onnx` і її конфігурацію `.json`."
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Користувальницькі голоси можуть бути встановлені за допомогою **Імпортувати з файлів**, обравши модель `.onnx` і її конфігурацію `.json`."
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Import Model from Files** کا استعمال کرتے ہوئے ایک **.onnx** ماڈل اور اس کی **.json** کنفیگریشن کو منتخب کر کے کسٹم آوازیں انسٹال کی جا سکتی ہیں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Import Model from Files** کا استعمال کرتے ہوئے ایک **.onnx** ماڈل اور اس کی **.json** کنفیگریشن کو منتخب کر کے کسٹم آوازیں انسٹال کی جا سکتی ہیں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "通过选择`.onnx`模型及其`.json`配置，可以使用 **从文件中导入模型** 安装自定义语音。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通过选择`.onnx`模型及其`.json`配置，可以使用 **从文件中导入模型** 安装自定义语音。"
           }
         }
       }
     },
-    "app_help_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مساعدة"
+    "app_help_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مساعدة"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "সাহায্য"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "সাহায্য"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hilfe"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hilfe"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Help"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Help"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ayuda"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ayuda"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aide"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aide"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सहायता"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सहायता"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Súgó"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Súgó"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bantuan"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bantuan"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aiuto"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aiuto"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ヘルプ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ヘルプ"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hulp"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hulp"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pomoc"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pomoc"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hjälp"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hjälp"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajuda"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajuda"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Yardım"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yardım"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Довідка"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Довідка"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Help"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Help"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "帮助"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "帮助"
           }
         }
       }
     },
-    "app_version": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إصدار التطبيق"
+    "app_version" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إصدار التطبيق"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "অ্যাপ সংস্করণ"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "অ্যাপ সংস্করণ"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "App-Version"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App-Version"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "App Version"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App Version"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versión de la aplicación"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versión de la aplicación"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version de l'application"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version de l'application"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ऐप वर्शन"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ऐप वर्शन"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alkalmazás verziója"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alkalmazás verziója"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versi Aplikasi"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versi Aplikasi"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versione app"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versione app"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アプリのバージョン"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリのバージョン"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "App-versie"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App-versie"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wersja aplikacji"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wersja aplikacji"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Appversion"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appversion"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versão do App"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versão do App"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uygulama Sürümü"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uygulama Sürümü"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Версія програми"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Версія програми"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ایپ کا ورژن"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایپ کا ورژن"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "应用版本"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用版本"
           }
         }
       }
     },
-    "app_voice_info": {
-      "comment": "A section header for displaying information about the app's voice capabilities.",
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "معلومات الصوت"
+    "app_voice_info" : {
+      "comment" : "A section header for displaying information about the app's voice capabilities.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "معلومات الصوت"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ভয়েস তথ্য"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ভয়েস তথ্য"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stimmen-Informationen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stimmen-Informationen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voice Information"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voice Information"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Información de la voz"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Información de la voz"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informations vocales"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informations vocales"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "आवाज़ की जानकारी"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "आवाज़ की जानकारी"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hanginformációk"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hanginformációk"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informasi Suara"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informasi Suara"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informazioni sulla voce"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informazioni sulla voce"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "音声情報"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音声情報"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stem-informatie"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stem-informatie"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informacje o głosach"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informacje o głosach"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Röstinformation"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Röstinformation"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informação da Voz"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informação da Voz"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ses Bilgisi"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ses Bilgisi"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Інформація про голос"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Інформація про голос"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "آواز کی معلومات"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "آواز کی معلومات"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "语音信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语音信息"
           }
         }
       }
     },
-    "audio_unit_status": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حالة وحدة الصوت"
+    "audio_unit_status" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حالة وحدة الصوت"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "অডিও ইউনিটের অবস্থা"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "অডিও ইউনিটের অবস্থা"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Audio-Unit-Status"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio-Unit-Status"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Audio Unit Status"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio Unit Status"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estado de Audio Unit"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estado de Audio Unit"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "État de l'Audio Unit"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "État de l'Audio Unit"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ऑडियो यूनिट स्थिति"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ऑडियो यूनिट स्थिति"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Audio Unit állapota"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio Unit állapota"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Status Unit Audio"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Status Unit Audio"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stato Audio Unit"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stato Audio Unit"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Audio Unit ステータス"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio Unit ステータス"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Audio Unit-status"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio Unit-status"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Status jednostki audio"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Status jednostki audio"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Audio Unit-status"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio Unit-status"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Status da Unidade de Áudio"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Status da Unidade de Áudio"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ses Birimi Durumu"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ses Birimi Durumu"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Статус Audio Unit"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Статус Audio Unit"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "آڈیو یونٹ کی حیثیت"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "آڈیو یونٹ کی حیثیت"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "音频设备状态"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音频设备状态"
           }
         }
       }
     },
-    "audio_unit_status_connected": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "متصل"
+    "audio_unit_status_connected" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "متصل"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "সংযুক্ত"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "সংযুক্ত"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verbunden"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbunden"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connected"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connected"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectado"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connecté"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connecté"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "जुड़ा हुआ"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "जुड़ा हुआ"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Csatlakozva"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Csatlakozva"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terhubung"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terhubung"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connesso"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connesso"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "接続済み"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接続済み"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verbonden"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbonden"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Połączono"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Połączono"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ansluten"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ansluten"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectado"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectado"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bağlı"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bağlı"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Підключено"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Підключено"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جڑا ہوا"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جڑا ہوا"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已连接"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已连接"
           }
         }
       }
     },
-    "audio_unit_status_disconnected": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "غير متصل"
+    "audio_unit_status_disconnected" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "غير متصل"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "সংযোগ বিচ্ছিন্ন"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "সংযোগ বিচ্ছিন্ন"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Getrennt"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Getrennt"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disconnected"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnected"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desconectado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desconectado"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Déconnecté"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Déconnecté"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "डिस्कनेक्ट किया गया"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "डिस्कनेक्ट किया गया"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Szétválasztva"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Szétválasztva"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terputus"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terputus"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disconnesso"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnesso"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "切断済み"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切断済み"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Niet verbonden"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niet verbonden"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rozłączono"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rozłączono"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Frånkopplad"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frånkopplad"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desconectado"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desconectado"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bağlantı Kesildi"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bağlantı Kesildi"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Відключено"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відключено"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "منقطع"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "منقطع"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "断开连接"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "断开连接"
           }
         }
       }
     },
-    "audio_unit_status_failed": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فشل الاتصال"
+    "audio_unit_status_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فشل الاتصال"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "সংযোগ করতে ব্যর্থ হয়েছে"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "সংযোগ করতে ব্যর্থ হয়েছে"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verbindung fehlgeschlagen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbindung fehlgeschlagen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to Connect"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to Connect"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error al conectar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error al conectar"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Échec de la connexion"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec de la connexion"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कनेक्ट करने में विफल"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कनेक्ट करने में विफल"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sikertelen csatlakozás"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sikertelen csatlakozás"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gagal Menghubungkan"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gagal Menghubungkan"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connessione non riuscita"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connessione non riuscita"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "接続に失敗しました"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接続に失敗しました"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verbinding mislukt"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbinding mislukt"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nie udało się połączyć"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie udało się połączyć"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anslutning misslyckades"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anslutning misslyckades"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falha ao Conectar"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falha ao Conectar"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bağlantı Başarısız"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bağlantı Başarısız"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Не вдалося підключитися"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося підключитися"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مربوط ہونے میں ناکام"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مربوط ہونے میں ناکام"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "连接失败"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连接失败"
           }
         }
       }
     },
-    "cancel": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إلغاء"
+    "cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إلغاء"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "বাতিল"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "বাতিল"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abbrechen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abbrechen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Annuler"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuler"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "रद्द करें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "रद्द करें"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mégse"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mégse"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Batal"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batal"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Annulla"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annulla"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キャンセル"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Annuleer"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuleer"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anuluj"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anuluj"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avbryt"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avbryt"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "İptal"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İptal"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Скасувати"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скасувати"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "منسوخ کریں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "منسوخ کریں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "取消"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
           }
         }
       }
     },
-    "connect": {
-      "comment": "A button label that says \"Connect\".",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اتصال"
+    "connect" : {
+      "comment" : "A button label that says \"Connect\".",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اتصال"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "সংযোগ করুন"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "সংযোগ করুন"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verbinden"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbinden"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connect"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connect"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectar"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connecter"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connecter"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कनेक्ट करें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कनेक्ट करें"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Csatlakozás"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Csatlakozás"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hubungkan"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hubungkan"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connetti"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connetti"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "接続"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接続"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verbind"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbind"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Połącz"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Połącz"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anslut"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anslut"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectar"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectar"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bağlan"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bağlan"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Підключитися"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Підключитися"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جڑیں"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جڑیں"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "连接"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连接"
           }
         }
       }
     },
-    "country": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "البلد"
+    "country" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "البلد"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "দেশ"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "দেশ"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Land"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Land"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Country"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Country"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "País"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "País"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pays"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pays"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "देश"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "देश"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ország"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ország"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Negara"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Negara"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Paese"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paese"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "国"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "国"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Land"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Land"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kraj"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kraj"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Land"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Land"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "País"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "País"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ülke"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ülke"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Країна"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Країна"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ملک"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ملک"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "国家"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "国家"
           }
         }
       }
     },
-    "credits_and_legal": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الاعتمادات والقانونية"
+    "credits_and_legal" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الاعتمادات والقانونية"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ক্রেডিট এবং আইনি"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ক্রেডিট এবং আইনি"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Danksagungen & Rechtliches"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Danksagungen & Rechtliches"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Credits & Legal"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Credits & Legal"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Créditos y aspectos legales"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Créditos y aspectos legales"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Crédits et mentions légales"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crédits et mentions légales"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "क्रेडिट और कानूनी"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "क्रेडिट और कानूनी"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Köszönetnyilvánítás és jogi nyilatkozat"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Köszönetnyilvánítás és jogi nyilatkozat"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kredit & Legal"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kredit & Legal"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Crediti e note legali"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crediti e note legali"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "クレジットと法律"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クレジットと法律"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Credits & juridisch"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Credits & juridisch"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autorzy i Licencje"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autorzy i Licencje"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tack & Juridisk information"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tack & Juridisk information"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Créditos e Jurídico"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Créditos e Jurídico"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Katkılar & Yasal"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Katkılar & Yasal"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Автори та Ліцензії"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автори та Ліцензії"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کریڈٹ اور لائسنس"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کریڈٹ اور لائسنس"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "学分与法律"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "学分与法律"
           }
         }
       }
     },
-    "download_voice": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تحميل الصوت"
+    "download_voice" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تحميل الصوت"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ভয়েস ডাউনলোড করুন"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ভয়েস ডাউনলোড করুন"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stimme herunterladen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stimme herunterladen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download Voice"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download Voice"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descargar voz"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargar voz"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Télécharger la voix"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Télécharger la voix"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "आवाज़ डाउनलोड करें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "आवाज़ डाउनलोड करें"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hang letöltése"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hang letöltése"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unduh Suara"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unduh Suara"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scarica voce"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scarica voce"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "音声をダウンロード"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音声をダウンロード"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download stem"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download stem"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pobierz głos"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pobierz głos"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ladda ner röst"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ladda ner röst"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Baixar Voz"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Baixar Voz"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sesi İndir"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sesi İndir"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Завантажити голос"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Завантажити голос"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "آواز ڈاؤن لوڈ کریں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "آواز ڈاؤن لوڈ کریں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "下载声音"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载声音"
           }
         }
       }
     },
-    "download_voice_model": {
-      "comment": "A button label that downloads a voice model.",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تحميل نموذج الصوت"
+    "download_voice_model" : {
+      "comment" : "A button label that downloads a voice model.",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تحميل نموذج الصوت"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ভয়েস মডেল ডাউনলোড করুন"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ভয়েস মডেল ডাউনলোড করুন"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sprachmodell herunterladen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprachmodell herunterladen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download Voice Model"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download Voice Model"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descargar modelo de voz"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargar modelo de voz"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Télécharger le modèle de voix"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Télécharger le modèle de voix"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "वॉयस मॉडल डाउनलोड करें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "वॉयस मॉडल डाउनलोड करें"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hangmodell letöltése"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hangmodell letöltése"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unduh Model Suara"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unduh Model Suara"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scarica modello vocale"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scarica modello vocale"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "音声モデルをダウンロード"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音声モデルをダウンロード"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download spraakmodel"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download spraakmodel"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pobierz model głosu"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pobierz model głosu"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ladda ner röstmodell"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ladda ner röstmodell"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Baixar Modelo de Voz"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Baixar Modelo de Voz"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ses Modelini İndir"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ses Modelini İndir"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Завантажити голосову модель"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Завантажити голосову модель"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "وائس ماڈل ڈاؤن لوڈ کریں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "وائس ماڈل ڈاؤن لوڈ کریں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "下载语音模型"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载语音模型"
           }
         }
       }
     },
-    "downloaded": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تم التحميل"
+    "downloaded" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم التحميل"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ডাউনলোড করা হয়েছে"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ডাউনলোড করা হয়েছে"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Heruntergeladen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heruntergeladen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Downloaded"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Downloaded"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descargado"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargado"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Téléchargé"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléchargé"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "डाउनलोड किया गया"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "डाउनलोड किया गया"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Letöltve"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letöltve"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terunduh"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terunduh"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scaricato"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scaricato"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ダウンロード済み"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロード済み"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gedownload"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gedownload"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pobrano"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pobrano"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nedladdad"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nedladdad"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Baixado"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Baixado"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "İndirildi"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İndirildi"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Завантажено"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Завантажено"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ڈاؤن لوڈ کیا گیا۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ڈاؤن لوڈ کیا گیا۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已下载"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已下载"
           }
         }
       }
     },
-    "downloading": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جاري التحميل"
+    "downloading" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جاري التحميل"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ডাউনলোড হচ্ছে"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ডাউনলোড হচ্ছে"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wird heruntergeladen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird heruntergeladen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Downloading"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Downloading"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descargando"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargando"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Téléchargement"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléchargement"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "डाउनलोड हो रहा है"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "डाउनलोड हो रहा है"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Letöltés"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letöltés"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mengunduh"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengunduh"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download in corso"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download in corso"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ダウンロード中"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロード中"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Downloaden"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Downloaden"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pobieranie"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pobieranie"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Laddar ner"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laddar ner"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Baixando"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Baixando"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "İndiriliyor"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İndiriliyor"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Завантажується"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Завантажується"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ڈاؤن لوڈ ہو رہا ہے۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ڈاؤن لوڈ ہو رہا ہے۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在下载"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在下载"
           }
         }
       }
     },
-    "error": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خطأ"
+    "error" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خطأ"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ত্রুটি"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ত্রুটি"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fehler"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fehler"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erreur"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erreur"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "त्रुटि"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "त्रुटि"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hiba"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hiba"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kesalahan"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kesalahan"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Errore"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Errore"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エラー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エラー"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fout"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fout"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pomyłka"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pomyłka"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fel"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fel"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erro"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erro"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hata"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hata"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Помилка"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Помилка"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خرابی"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خرابی"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "错误"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "错误"
           }
         }
       }
     },
-    "export_file": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تصدير الملف"
+    "export_file" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تصدير الملف"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ফাইল এক্সপোর্ট করুন"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ফাইল এক্সপোর্ট করুন"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Datei exportieren"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datei exportieren"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Export File"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Export File"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exportar archivo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exportar archivo"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exporter le fichier"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exporter le fichier"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "फ़ाइल एक्सपोर्ट करें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "फ़ाइल एक्सपोर्ट करें"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fájl exportálása"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fájl exportálása"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ekspor Berkas"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ekspor Berkas"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esporta file"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esporta file"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ファイルを書き出す"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイルを書き出す"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exporteer bestand"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exporteer bestand"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eksportuj plik"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eksportuj plik"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exportera fil"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exportera fil"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exportar Arquivo"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exportar Arquivo"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dosyayı Dışa Aktar"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dosyayı Dışa Aktar"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Отримати запис"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отримати запис"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فائل برآمد کریں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فائل برآمد کریں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "导出文件"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导出文件"
           }
         }
       }
     },
-    "installed_voices": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الأصوات المثبتة"
+    "installed_voices" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الأصوات المثبتة"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ইনস্টল করা ভয়েস"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ইনস্টল করা ভয়েস"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installierte Stimmen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installierte Stimmen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installed Voices"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Voices"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voces instaladas"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voces instaladas"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voix installées"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voix installées"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "इंस्टॉल की गई आवाज़ें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "इंस्टॉल की गई आवाज़ें"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Telepített hangok"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Telepített hangok"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Suara Terinstal"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suara Terinstal"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voci installate"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voci installate"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インストール済みの音声"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インストール済みの音声"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Geïnstalleerde stemmen"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geïnstalleerde stemmen"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zainstalowane głosy"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zainstalowane głosy"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installerade röster"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installerade röster"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vozes Instaladas"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vozes Instaladas"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Yüklenen Sesler"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yüklenen Sesler"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Встановлені Голоси"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Встановлені Голоси"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "انسٹال شدہ آوازیں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انسٹال شدہ آوازیں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已安装的声音"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已安装的声音"
           }
         }
       }
     },
-    "json_error_data_corrupted_%@": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "البيانات تالفة: %@"
+    "json_error_data_corrupted_%@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "البيانات تالفة: %@"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "তথ্য দূষিত: %@"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "তথ্য দূষিত: %@"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Daten sind beschädigt: %@"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Daten sind beschädigt: %@"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The data is corrupted: %@"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The data is corrupted: %@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los datos están dañados: %@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los datos están dañados: %@"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Les données sont corrompues : %@"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les données sont corrompues : %@"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "डेटा दूषित है: %@"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "डेटा दूषित है: %@"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Az adatok sérültek: %@"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Az adatok sérültek: %@"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Data korup: %@"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data korup: %@"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I dati sono corrotti: %@"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I dati sono corrotti: %@"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "データが破損しています: %@"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データが破損しています: %@"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "De gegevens zijn beschadigd: %@"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De gegevens zijn beschadigd: %@"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dane są uszkodzone: %@"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dane są uszkodzone: %@"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Datan är korrupt: %@"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datan är korrupt: %@"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Os dados estão corrompidos: %@"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Os dados estão corrompidos: %@"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Veriler bozulmuş: %@"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Veriler bozulmuş: %@"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Дані пошкоджені: %@"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дані пошкоджені: %@"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ڈیٹا کرپٹ ہے: %@"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ڈیٹا کرپٹ ہے: %@"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "数据已损坏：%@"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数据已损坏：%@"
           }
         }
       }
     },
-    "json_error_invalid_model_file_path": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مسار ملف النموذج غير صالح."
+    "json_error_invalid_model_file_path" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مسار ملف النموذج غير صالح."
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "অবৈধ মডেল ফাইল পাথ।"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "অবৈধ মডেল ফাইল পাথ।"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ungültiger Modell-Dateipfad."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungültiger Modell-Dateipfad."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid model file path."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invalid model file path."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ruta del archivo del modelo no válida."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ruta del archivo del modelo no válida."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chemin du fichier de modèle invalide."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chemin du fichier de modèle invalide."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अमान्य मॉडल फ़ाइल पथ।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अमान्य मॉडल फ़ाइल पथ।"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Érvénytelen modellfájl elérési út."
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Érvénytelen modellfájl elérési út."
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jalur berkas model tidak valid."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jalur berkas model tidak valid."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Percorso del file del modello non valido."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Percorso del file del modello non valido."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "モデルファイルのパスが無効です。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "モデルファイルのパスが無効です。"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ongeldig bestandspad voor model."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ongeldig bestandspad voor model."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nieprawidłowa ścieżka do pliku modelu."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nieprawidłowa ścieżka do pliku modelu."
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ogiltig filsökväg för modell."
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ogiltig filsökväg för modell."
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Caminho de arquivo de modelo inválido."
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Caminho de arquivo de modelo inválido."
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Geçersiz model dosya yolu."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geçersiz model dosya yolu."
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Недійсний шлях до файлу моделі."
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Недійсний шлях до файлу моделі."
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "غلط ماڈل فائل پاتھ۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "غلط ماڈل فائل پاتھ۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "模型文件路径无效。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模型文件路径无效。"
           }
         }
       }
     },
-    "json_error_missing_field_%@_at_%@": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الحقل ‘%@’ مفقود في ‘%@’"
+    "json_error_missing_field_%@_at_%@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الحقل ‘%@’ مفقود في ‘%@’"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‘%@’ ক্ষেত্রটি ‘%@’ এ অনুপস্থিত"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‘%@’ ক্ষেত্রটি ‘%@’ এ অনুপস্থিত"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Das Feld ‘%@’ fehlt bei ‘%@’"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das Feld ‘%@’ fehlt bei ‘%@’"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The field ‘%@’ is missing at ‘%@’"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The field ‘%@’ is missing at ‘%@’"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falta el campo ‘%@’ en ‘%@’"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falta el campo ‘%@’ en ‘%@’"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Le champ ‘%@’ est manquant à ‘%@’"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le champ ‘%@’ est manquant à ‘%@’"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‘%@’ फ़ील्ड ‘%@’ पर गायब है"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‘%@’ फ़ील्ड ‘%@’ पर गायब है"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A(z) ‘%@’ mező hiányzik itt: ‘%@’"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A(z) ‘%@’ mező hiányzik itt: ‘%@’"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bidang ‘%@’ tidak ditemukan di ‘%@’"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bidang ‘%@’ tidak ditemukan di ‘%@’"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Il campo ‘%@’ è mancante in ‘%@’"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il campo ‘%@’ è mancante in ‘%@’"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‘%@’ フィールドが ‘%@’ に見つかりません"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‘%@’ フィールドが ‘%@’ に見つかりません"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Het veld ‘%@’ ontbreekt bij ‘%@’"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Het veld ‘%@’ ontbreekt bij ‘%@’"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pole „%@” nie występuje w „%@”"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pole „%@” nie występuje w „%@”"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fältet ‘%@’ saknas vid ‘%@’"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fältet ‘%@’ saknas vid ‘%@’"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O campo ‘%@’ está faltando em ‘%@’"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O campo ‘%@’ está faltando em ‘%@’"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "‘%@’ alanı ‘%@’ konumunda eksik."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‘%@’ alanı ‘%@’ konumunda eksik."
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Поле «%@» відсутнє у «%@»"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поле «%@» відсутнє у «%@»"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فیلڈ '%@' '%@' پر غائب ہے"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فیلڈ '%@' '%@' پر غائب ہے"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "字段“%@”在“%@”处缺失"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字段“%@”在“%@”处缺失"
           }
         }
       }
     },
-    "json_error_type_mismatch_%@_at_%@": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "توقع قيمة من نوع '%@' في '%@'، ولكن وجد شيء آخر."
+    "json_error_type_mismatch_%@_at_%@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "توقع قيمة من نوع '%@' في '%@'، ولكن وجد شيء آخر."
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "'%@' এ '%@' টাইপের মান প্রত্যাশিত ছিল, কিন্তু অন্য কিছু পাওয়া গেছে।"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "'%@' এ '%@' টাইপের মান প্রত্যাশিত ছিল, কিন্তু অন্য কিছু পাওয়া গেছে।"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wert vom Typ '%@' bei '%@' erwartet, aber etwas anderes gefunden."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wert vom Typ '%@' bei '%@' erwartet, aber etwas anderes gefunden."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expected a value of type '%@' at '%@', but found something else."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expected a value of type '%@' at '%@', but found something else."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se esperaba un valor de tipo '%@' en '%@', pero se encontró otra cosa."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se esperaba un valor de tipo '%@' en '%@', pero se encontró otra cosa."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valeur de type '%@' attendue à '%@', mais autre chose a été trouvé."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valeur de type '%@' attendue à '%@', mais autre chose a été trouvé."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "'%@' पर '%@' प्रकार के मान की अपेक्षा थी, लेकिन कुछ और मिला।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "'%@' पर '%@' प्रकार के मान की अपेक्षा थी, लेकिन कुछ और मिला।"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "'%@' típusú értéket vártunk a(z) '%@' helyen, de mást találtunk."
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "'%@' típusú értéket vártunk a(z) '%@' helyen, de mást találtunk."
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mengharapkan nilai tipe '%@' di '%@', tetapi menemukan hal lain."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengharapkan nilai tipe '%@' di '%@', tetapi menemukan hal lain."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atteso un valore di tipo '%@' in '%@', ma è stato trovato altro."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atteso un valore di tipo '%@' in '%@', ma è stato trovato altro."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "'%@' にタイプ '%@' の値が期待されましたが、別のものが見つかりました。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "'%@' にタイプ '%@' の値が期待されましたが、別のものが見つかりました。"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verwachtte een waarde van type '%@' bij '%@', maar vond iets anders."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verwachtte een waarde van type '%@' bij '%@', maar vond iets anders."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Oczekiwano wartości typu '%@' w '%@', ale znaleziono coś innego."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oczekiwano wartości typu '%@' w '%@', ale znaleziono coś innego."
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Väntade ett värde av typen '%@' vid '%@', men hittade något annat."
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Väntade ett värde av typen '%@' vid '%@', men hittade något annat."
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esperava um valor do tipo '%@' em '%@', mas encontrou outra coisa."
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esperava um valor do tipo '%@' em '%@', mas encontrou outra coisa."
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "'%@' konumunda '%@' türünde bir değer bekleniyordu, ancak başka bir şey bulundu."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "'%@' konumunda '%@' türünde bir değer bekleniyordu, ancak başka bir şey bulundu."
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Очікувалося значення типу '%@' у '%@', але знайдено щось інше."
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очікувалося значення типу '%@' у '%@', але знайдено щось інше."
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "'%@' پر '%@' قسم کی قدر کی توقع تھی، لیکن کچھ اور ملا۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "'%@' پر '%@' قسم کی قدر کی توقع تھی، لیکن کچھ اور ملا۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "预期在“%@”处找到类型为“%@”的值，但找到的是其他类型。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预期在“%@”处找到类型为“%@”的值，但找到的是其他类型。"
           }
         }
       }
     },
-    "json_error_value_not_found_%@_at_%@": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "القيمة المطلوبة من نوع '%@' كانت فارغة في '%@'."
+    "json_error_value_not_found_%@_at_%@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "القيمة المطلوبة من نوع '%@' كانت فارغة في '%@'."
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "'%@' এ '%@' টাইপের প্রয়োজনীয় মানটি শূন্য ছিল।"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "'%@' এ '%@' টাইপের প্রয়োজনীয় মানটি শূন্য ছিল।"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erforderlicher Wert vom Typ '%@' war null bei '%@'."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erforderlicher Wert vom Typ '%@' war null bei '%@'."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Required value of type '%@' was null at '%@'."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Required value of type '%@' was null at '%@'."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El valor requerido de tipo '%@' era nulo en '%@'."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El valor requerido de tipo '%@' era nulo en '%@'."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La valeur requise de type '%@' était nulle à '%@'."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La valeur requise de type '%@' était nulle à '%@'."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "'%@' प्रकार का आवश्यक मान '%@' पर शून्य (null) था।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "'%@' प्रकार का आवश्यक मान '%@' पर शून्य (null) था।"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A(z) '%@' típusú kötelező érték null volt itt: '%@'."
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A(z) '%@' típusú kötelező érték null volt itt: '%@'."
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nilai yang diperlukan dari tipe '%@' adalah null di '%@'."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nilai yang diperlukan dari tipe '%@' adalah null di '%@'."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Il valore richiesto di tipo '%@' era nullo in '%@'."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il valore richiesto di tipo '%@' era nullo in '%@'."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "'%@' に必要なタイプ '%@' の値が NULL でした。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "'%@' に必要なタイプ '%@' の値が NULL でした。"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vereiste waarde van type '%@' was null bij '%@'."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vereiste waarde van type '%@' was null bij '%@'."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wymagana wartość typu '%@' była równa null dla '%@'."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wymagana wartość typu '%@' była równa null dla '%@'."
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nödvändigt värde av typen '%@' saknades vid '%@'."
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nödvändigt värde av typen '%@' saknades vid '%@'."
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O valor obrigatório do tipo '%@' era nulo em '%@'."
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O valor obrigatório do tipo '%@' era nulo em '%@'."
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "'%@' türündeki gerekli değer '%@' konumunda boştu."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "'%@' türündeki gerekli değer '%@' konumunda boştu."
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Необхідне значення типу '%@' було null у '%@'."
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Необхідне значення типу '%@' було null у '%@'."
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "قسم '%@' کی مطلوبہ قدر '%@' پر کالعدم تھی۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قسم '%@' کی مطلوبہ قدر '%@' پر کالعدم تھی۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "类型为“%@”的必需值为空。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "类型为“%@”的必需值为空。"
           }
         }
       }
     },
-    "language": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اللغة"
+    "language" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اللغة"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ভাষা"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ভাষা"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sprache"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprache"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Language"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Language"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Idioma"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Idioma"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Langue"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Langue"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "भाषा"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "भाषा"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nyelv"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nyelv"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lingua"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lingua"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "言語"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "言語"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taal"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taal"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bahasa"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bahasa"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Język"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Język"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Språk"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Språk"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Idioma"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Idioma"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dil"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dil"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Мова"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Мова"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "زبان"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "زبان"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "语言"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语言"
           }
         }
       }
     },
-    "languages": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اللغات"
+    "languages" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اللغات"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ভাষাগুলো"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ভাষাগুলো"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sprachen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprachen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Languages"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Languages"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Idiomas"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Idiomas"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Langues"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Langues"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "भाषाएँ"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "भाषाएँ"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nyelvek"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nyelvek"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lingue"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lingue"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "言語"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "言語"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Talen"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Talen"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bahasa"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bahasa"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Języki"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Języki"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Språk"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Språk"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Idiomas"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Idiomas"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Diller"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diller"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Мови"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Мови"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "زبانیں"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "زبانیں"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "语言"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语言"
           }
         }
       }
     },
-    "license_audio_unit_description": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ملحق وحدة الصوت هذا، الذي يتضمن eSpeak-NG و Piper1-GPL، مرخص تحت GPLv3."
+    "license_audio_unit_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ملحق وحدة الصوت هذا، الذي يتضمن eSpeak-NG و Piper1-GPL، مرخص تحت GPLv3."
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "এই অডিও ইউনিট এক্সটেন্সন, যার মধ্যে eSpeak-NG এবং Piper1-GPL অন্তর্ভুক্ত রয়েছে, GPLv3 এর অধীনে লাইসেন্সপ্রাপ্ত।"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "এই অডিও ইউনিট এক্সটেন্সন, যার মধ্যে eSpeak-NG এবং Piper1-GPL অন্তর্ভুক্ত রয়েছে, GPLv3 এর অধীনে লাইসেন্সপ্রাপ্ত।"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Diese Audio-Unit-Erweiterung, die eSpeak-NG und Piper1-GPL enthält, ist unter der GPLv3 lizenziert."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Audio-Unit-Erweiterung, die eSpeak-NG und Piper1-GPL enthält, ist unter der GPLv3 lizenziert."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This Audio Unit Extension, which includes eSpeak-NG and Piper1-GPL, is licensed under GPLv3."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This Audio Unit Extension, which includes eSpeak-NG and Piper1-GPL, is licensed under GPLv3."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esta extensión de Audio Unit, que incluye eSpeak-NG y Piper1-GPL, tiene licencia GPLv3."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta extensión de Audio Unit, que incluye eSpeak-NG y Piper1-GPL, tiene licencia GPLv3."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cette extension Audio Unit, qui inclut eSpeak-NG et Piper1-GPL, est sous licence GPLv3."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cette extension Audio Unit, qui inclut eSpeak-NG et Piper1-GPL, est sous licence GPLv3."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "यह ऑडियो यूनिट एक्सटेंशन, जिसमें eSpeak-NG और Piper1-GPL शामिल हैं, GPLv3 के तहत लाइसेंस प्राप्त है।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "यह ऑडियो यूनिट एक्सटेंशन, जिसमें eSpeak-NG और Piper1-GPL शामिल हैं, GPLv3 के तहत लाइसेंस प्राप्त है।"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ez az Audio Unit bővítmény, amely tartalmazza az eSpeak-NG-t és a Piper1-GPL-t, a GPLv3 licenc alatt áll."
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ez az Audio Unit bővítmény, amely tartalmazza az eSpeak-NG-t és a Piper1-GPL-t, a GPLv3 licenc alatt áll."
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ekstensi Unit Audio ini, yang mencakup eSpeak-NG dan Piper1-GPL, dilisensikan di bawah GPLv3."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ekstensi Unit Audio ini, yang mencakup eSpeak-NG dan Piper1-GPL, dilisensikan di bawah GPLv3."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Questa estensione Audio Unit, che include eSpeak-NG e Piper1-GPL, è concessa in licenza sotto GPLv3."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questa estensione Audio Unit, che include eSpeak-NG e Piper1-GPL, è concessa in licenza sotto GPLv3."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak-NG と Piper1-GPL を含むこの Audio Unit 拡張機能は、GPLv3 に基づいてライセンスされています。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak-NG と Piper1-GPL を含むこの Audio Unit 拡張機能は、GPLv3 に基づいてライセンスされています。"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deze Audio Unit-extensie, inclusief eSpeak-NG en Piper1-GPL, is gelicentieerd onder GPLv3."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deze Audio Unit-extensie, inclusief eSpeak-NG en Piper1-GPL, is gelicentieerd onder GPLv3."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "To rozszerzenie Audio Unit, które zawiera eSpeak-NG i Piper1-GPL, jest licencjonowane na GPLv3."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To rozszerzenie Audio Unit, które zawiera eSpeak-NG i Piper1-GPL, jest licencjonowane na GPLv3."
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Detta Audio Unit-tillägg, som inkluderar eSpeak-NG och Piper1-GPL, är licensierat under GPLv3."
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detta Audio Unit-tillägg, som inkluderar eSpeak-NG och Piper1-GPL, är licensierat under GPLv3."
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esta Extensão de Unidade de Áudio, que inclui eSpeak-NG e Piper1-GPL, é licenciada sob a GPLv3."
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta Extensão de Unidade de Áudio, que inclui eSpeak-NG e Piper1-GPL, é licenciada sob a GPLv3."
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak-NG ve Piper1-GPL içeren bu Ses Birimi Eklentisi GPLv3 lisanslıdır."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak-NG ve Piper1-GPL içeren bu Ses Birimi Eklentisi GPLv3 lisanslıdır."
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Цей Audio Unit Extension, що включає eSpeak-NG та Piper1-GPL, ліцензований за GPLv3."
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Цей Audio Unit Extension, що включає eSpeak-NG та Piper1-GPL, ліцензований за GPLv3."
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "یہ آڈیو یونٹ ایکسٹینشن، جس میں eSpeak-NG اور Piper1-GPL شامل ہیں، GPLv3 کے تحت  لائسنس یافتہ ہے۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یہ آڈیو یونٹ ایکسٹینشن، جس میں eSpeak-NG اور Piper1-GPL شامل ہیں، GPLv3 کے تحت  لائسنس یافتہ ہے۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "此音频单元扩展包括eSpeak-NG和 Piper1-GPL，它是GPLv3授权的。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此音频单元扩展包括eSpeak-NG和 Piper1-GPL，它是GPLv3授权的。"
           }
         }
       }
     },
-    "license_audio_unit_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ملحق وحدة الصوت (GPLv3)"
+    "license_audio_unit_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ملحق وحدة الصوت (GPLv3)"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "অডিও ইউনিট এক্সটেনশন (GPLv3)"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "অডিও ইউনিট এক্সটেনশন (GPLv3)"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Audio-Unit-Erweiterung (GPLv3)"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio-Unit-Erweiterung (GPLv3)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Audio Unit Extension (GPLv3)"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio Unit Extension (GPLv3)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Extensión de Audio Unit (GPLv3)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Extensión de Audio Unit (GPLv3)"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Extension Audio Unit (GPLv3)"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Extension Audio Unit (GPLv3)"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ऑडियो यूनिट एक्सटेंशन (GPLv3)"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ऑडियो यूनिट एक्सटेंशन (GPLv3)"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Audio Unit bővítmény (GPLv3)"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio Unit bővítmény (GPLv3)"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ekstensi Unit Audio (GPLv3)"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ekstensi Unit Audio (GPLv3)"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estensione Audio Unit (GPLv3)"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estensione Audio Unit (GPLv3)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Audio Unit 拡張機能 (GPLv3)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio Unit 拡張機能 (GPLv3)"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Audio Unit-extensie (GPLv3)"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio Unit-extensie (GPLv3)"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rozszerzenie Audio Unit (GPLv3)"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rozszerzenie Audio Unit (GPLv3)"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Audio Unit-tillägg (GPLv3)"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio Unit-tillägg (GPLv3)"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Extensão de Unidade de Áudio (GPLv3)"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Extensão de Unidade de Áudio (GPLv3)"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ses Birimi Eklentisi (GPLv3)"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ses Birimi Eklentisi (GPLv3)"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Audio Unit Extension (GPLv3)"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio Unit Extension (GPLv3)"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "آڈیو یونٹ ایکسٹینشن (GPLv3)"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "آڈیو یونٹ ایکسٹینشن (GPLv3)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "音频单元扩展 (GPLv3)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音频单元扩展 (GPLv3)"
           }
         }
       }
     },
-    "license_espeak_ng_description": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak NG هو محرك نطق خفيف الوزن ومفتوح المصدر يدعم أكثر من 100 لغة ولهجة."
+    "license_espeak_ng_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak NG هو محرك نطق خفيف الوزن ومفتوح المصدر يدعم أكثر من 100 لغة ولهجة."
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak NG একটি হালকা ওপেন-সোর্স টেক্সট-টু-স্পিচ ইঞ্জিন যা ১০০টিরও বেশি ভাষা এবং অ্যাকসেন্ট সমর্থন করে।"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak NG একটি হালকা ওপেন-সোর্স টেক্সট-টু-স্পিচ ইঞ্জিন যা ১০০টিরও বেশি ভাষা এবং অ্যাকসেন্ট সমর্থন করে।"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak NG ist eine leichtgewichtige Open-Source-Text-to-Speech-Engine, die über 100 Sprachen und Akzente unterstützt."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak NG ist eine leichtgewichtige Open-Source-Text-to-Speech-Engine, die über 100 Sprachen und Akzente unterstützt."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak NG is a lightweight open-source text-to-speech engine supporting over 100 languages and accents."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak NG is a lightweight open-source text-to-speech engine supporting over 100 languages and accents."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak NG es un motor de texto a voz de código abierto y ligero que admite más de 100 idiomas y acentos."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak NG es un motor de texto a voz de código abierto y ligero que admite más de 100 idiomas y acentos."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak NG est un moteur de synthèse vocale open source léger prenant en charge plus de 100 langues et accents."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak NG est un moteur de synthèse vocale open source léger prenant en charge plus de 100 langues et accents."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak NG एक हल्का ओपन-सोर्स टेक्स्ट-टू-स्पीच इंजन है जो 100 से अधिक भाषाओं और लहजों का समर्थन करता है।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak NG एक हल्का ओपन-सोर्स टेक्स्ट-टू-स्पीच इंजन है जो 100 से अधिक भाषाओं और लहजों का समर्थन करता है।"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Az eSpeak NG egy könnyű, nyílt forráskódú szövegfelolvasó motor, amely több mint 100 nyelvet és akcentust támogat."
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Az eSpeak NG egy könnyű, nyílt forráskódú szövegfelolvasó motor, amely több mint 100 nyelvet és akcentust támogat."
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak NG adalah mesin text-to-speech sumber terbuka ringan yang mendukung lebih dari 100 bahasa dan aksen."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak NG adalah mesin text-to-speech sumber terbuka ringan yang mendukung lebih dari 100 bahasa dan aksen."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak NG è un motore di sintesi vocale open source leggero che supporta oltre 100 lingue e accenti."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak NG è un motore di sintesi vocale open source leggero che supporta oltre 100 lingue e accenti."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak NG は、100 以上の言語とアクセントをサポートする軽量のオープンソース テキスト読み上げエンジンです。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak NG は、100 以上の言語とアクセントをサポートする軽量のオープンソース テキスト読み上げエンジンです。"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak NG is een lichtgewicht open-source tekst-naar-spraak-engine die meer dan 100 talen en accenten ondersteunt."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak NG is een lichtgewicht open-source tekst-naar-spraak-engine die meer dan 100 talen en accenten ondersteunt."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak NG to lekki, otwartoźródłowy silnik TTS obsługujący ponad 100 języków i akcentów."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak NG to lekki, otwartoźródłowy silnik TTS obsługujący ponad 100 języków i akcentów."
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak NG är en lättviktig text-till-tal-motor med öppen källkod som stöder över 100 språk och dialekter."
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak NG är en lättviktig text-till-tal-motor med öppen källkod som stöder över 100 språk och dialekter."
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "o eSpeak NG é um mecanismo de conversão de texto em fala de código aberto leve que suporta mais de 100 idiomas e sotaques."
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "o eSpeak NG é um mecanismo de conversão de texto em fala de código aberto leve que suporta mais de 100 idiomas e sotaques."
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak NG, 100’den fazla dili ve aksanı destekleyen hafif açık kaynaklı bir metinden konuşmaya motorudur."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak NG, 100’den fazla dili ve aksanı destekleyen hafif açık kaynaklı bir metinden konuşmaya motorudur."
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak NG - це швидкий механізм перетворення тексту в мовлення з відкритим кодом, який підтримує понад 100 мов та акцентів."
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak NG - це швидкий механізм перетворення тексту в мовлення з відкритим кодом, який підтримує понад 100 мов та акцентів."
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak NG ایک ہلکا پھلکا اوپن سورس ٹیکسٹ ٹو اسپیچ انجن ہے جو 100 سے زیادہ زبانوں اور لہجوں کو سپورٹ کرتا ہے۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak NG ایک ہلکا پھلکا اوپن سورس ٹیکسٹ ٹو اسپیچ انجن ہے جو 100 سے زیادہ زبانوں اور لہجوں کو سپورٹ کرتا ہے۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "eSpeak NG 是一个轻量开源文字转语音引擎，支持100多种语言和音量。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eSpeak NG 是一个轻量开源文字转语音引擎，支持100多种语言和音量。"
           }
         }
       }
     },
-    "license_main_app_%@_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تطبيق Piper %@ (MIT)"
+    "license_main_app_%@_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تطبيق Piper %@ (MIT)"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper %@ অ্যাপ (MIT)"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper %@ অ্যাপ (MIT)"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper %@ App (MIT)"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper %@ App (MIT)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper %@ App (MIT)"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper %@ App (MIT)"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aplicación Piper %@ (MIT)"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplicación Piper %@ (MIT)"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Application Piper %@ (MIT)"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Application Piper %@ (MIT)"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "पाइपर %@ ऐप (MIT)"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "पाइपर %@ ऐप (MIT)"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper %@ alkalmazás (MIT)"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper %@ alkalmazás (MIT)"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aplikasi Piper %@ (MIT)"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplikasi Piper %@ (MIT)"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "App Piper %@ (MIT)"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App Piper %@ (MIT)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper %@ アプリ (MIT)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper %@ アプリ (MIT)"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper %@ App (MIT)"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper %@ App (MIT)"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper %@ Aplikacja (MIT)"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper %@ Aplikacja (MIT)"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper %@ App (MIT)"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper %@ App (MIT)"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "App Piper %@ (MIT)"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App Piper %@ (MIT)"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper %@ Uygulaması (MIT)"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper %@ Uygulaması (MIT)"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper %@ Додаток (MIT)"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper %@ Додаток (MIT)"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper %@ App (MIT)"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper %@ App (MIT)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper %@ App (MIT)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper %@ App (MIT)"
           }
         }
       }
     },
-    "license_main_app_description": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تطبيق Piper، الذي طوره [Ihor Shevchuk](https://ihor-shevchuk.dev)، مرخص تحت MIT. إنه برنامج منفصل ويتواصل مع ملحق وحدة الصوت فقط عبر XPC."
+    "license_main_app_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تطبيق Piper، الذي طوره [Ihor Shevchuk](https://ihor-shevchuk.dev)، مرخص تحت MIT. إنه برنامج منفصل ويتواصل مع ملحق وحدة الصوت فقط عبر XPC."
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "[Ihor Shevchuk](https://ihor-shevchuk.dev) দ্বারা তৈরি পাইপার অ্যাপটি MIT এর অধীনে লাইসেন্সপ্রাপ্ত। এটি একটি পৃথক প্রোগ্রাম এবং শুধুমাত্র XPC এর মাধ্যমে অডিও ইউনিট এক্সটেন্সনের সাথে যোগাযোগ করে।"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[Ihor Shevchuk](https://ihor-shevchuk.dev) দ্বারা তৈরি পাইপার অ্যাপটি MIT এর অধীনে লাইসেন্সপ্রাপ্ত। এটি একটি পৃথক প্রোগ্রাম এবং শুধুমাত্র XPC এর মাধ্যমে অডিও ইউনিট এক্সটেন্সনের সাথে যোগাযোগ করে।"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Piper-App, entwickelt von Ihor Shevchuk, steht unter der MIT-Lizenz. Sie ist ein eigenständiges Programm und kommuniziert mit der Audio-Unit-Erweiterung ausschließlich über XPC."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Piper-App, entwickelt von Ihor Shevchuk, steht unter der MIT-Lizenz. Sie ist ein eigenständiges Programm und kommuniziert mit der Audio-Unit-Erweiterung ausschließlich über XPC."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper App, developed by [Ihor Shevchuk](https://ihor-shevchuk.dev), is licensed under MIT. It is a separate program and communicates with the Audio Unit Extension only via XPC."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper App, developed by [Ihor Shevchuk](https://ihor-shevchuk.dev), is licensed under MIT. It is a separate program and communicates with the Audio Unit Extension only via XPC."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La aplicación Piper, desarrollada por Ihor Shevchuk, tiene licencia MIT. Es un programa independiente y se comunica con la extensión de Audio Unit solo a través de XPC."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La aplicación Piper, desarrollada por Ihor Shevchuk, tiene licencia MIT. Es un programa independiente y se comunica con la extensión de Audio Unit solo a través de XPC."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "L'application Piper, développée par Ihor Shevchuk, est sous licence MIT. Il s'agit d'un programme distinct qui communique avec l'extension Audio Unit uniquement via XPC."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'application Piper, développée par Ihor Shevchuk, est sous licence MIT. Il s'agit d'un programme distinct qui communique avec l'extension Audio Unit uniquement via XPC."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "पाइपर ऐप, Ihor Shevchuk द्वारा विकसित, MIT के तहत लाइसेंस प्राप्त है। यह एक अलग प्रोग्राम है और केवल XPC के माध्यम से ऑडियो यूनिट एक्सटेंशन के साथ संचार करता है।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "पाइपर ऐप, Ihor Shevchuk द्वारा विकसित, MIT के तहत लाइसेंस प्राप्त है। यह एक अलग प्रोग्राम है और केवल XPC के माध्यम से ऑडियो यूनिट एक्सटेंशन के साथ संचार करता है।"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A Piper alkalmazás, amelyet Ihor Shevchuk fejlesztett ki, MIT licenc alatt áll. Ez egy különálló program, amely kizárólag XPC-n keresztül kommunikál az Audio Unit bővítménnyel."
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A Piper alkalmazás, amelyet Ihor Shevchuk fejlesztett ki, MIT licenc alatt áll. Ez egy különálló program, amely kizárólag XPC-n keresztül kommunikál az Audio Unit bővítménnyel."
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aplikasi Piper, dikembangkan oleh [Ihor Shevchuk](https://ihor-shevchuk.dev), dilisensikan di bawah MIT. Ini adalah program terpisah dan berkomunikasi dengan Ekstensi Unit Audio hanya melalui XPC."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplikasi Piper, dikembangkan oleh [Ihor Shevchuk](https://ihor-shevchuk.dev), dilisensikan di bawah MIT. Ini adalah program terpisah dan berkomunikasi dengan Ekstensi Unit Audio hanya melalui XPC."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "L'app Piper, sviluppata da Ihor Shevchuk, è concessa in licenza sotto MIT. È un programma separato e comunica con l'estensione Audio Unit solo tramite XPC."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'app Piper, sviluppata da Ihor Shevchuk, è concessa in licenza sotto MIT. È un programma separato e comunica con l'estensione Audio Unit solo tramite XPC."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ihor Shevchuk によって開発された Piper アプリは、MIT に基づいてライセンスされています。これは別のプログラムであり、XPC 経由でのみ Audio Unit 拡張機能と通信します。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ihor Shevchuk によって開発された Piper アプリは、MIT に基づいてライセンスされています。これは別のプログラムであり、XPC 経由でのみ Audio Unit 拡張機能と通信します。"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "De Piper App, ontwikkeld door Ihor Shevchuk, is gelicentieerd onder MIT. Het is een apart programma en communiceert alleen via XPC met de Audio Unit-extensie."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De Piper App, ontwikkeld door Ihor Shevchuk, is gelicentieerd onder MIT. Het is een apart programma en communiceert alleen via XPC met de Audio Unit-extensie."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aplikacja Piper, stworzona przez [Ihora Szewczuka](https://ihor-shevchuk.dev), jest licencjonowana na MIT. To osobny program, który komunikuje się z rozszerzeniem Audio Unit wyłącznie przez XPC."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplikacja Piper, stworzona przez [Ihora Szewczuka](https://ihor-shevchuk.dev), jest licencjonowana na MIT. To osobny program, który komunikuje się z rozszerzeniem Audio Unit wyłącznie przez XPC."
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper App, utvecklad av Ihor Shevchuk, är licensierad under MIT. Det är ett separat program och kommunicerar endast med Audio Unit-tillägget via XPC."
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper App, utvecklad av Ihor Shevchuk, är licensierad under MIT. Det är ett separat program och kommunicerar endast med Audio Unit-tillägget via XPC."
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O App Piper, desenvolvido por [Ihor Shevchuk](https://ihor-shevchuk.dev), é licenciado sob a MIT. É um programa separado e se comunica com a Extensão de Unidade de Áudio apenas via XPC."
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O App Piper, desenvolvido por [Ihor Shevchuk](https://ihor-shevchuk.dev), é licenciado sob a MIT. É um programa separado e se comunica com a Extensão de Unidade de Áudio apenas via XPC."
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "[Ihor Shevchuk](https://ihor-shevchuk.dev) tarafından geliştirilen Piper Uygulaması MIT lisanslıdır. Bu ayrı bir programdır ve Ses Birimi Eklentisi ile yalnızca XPC üzerinden iletişim kurar."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[Ihor Shevchuk](https://ihor-shevchuk.dev) tarafından geliştirilen Piper Uygulaması MIT lisanslıdır. Bu ayrı bir programdır ve Ses Birimi Eklentisi ile yalnızca XPC üzerinden iletişim kurar."
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Додаток Piper, розроблений [Ігорем Шевчуком](https://ihor-shevchuk.dev), ліцензований за MIT. Це окрема програма, яка взаємодіє з Audio Unit Extension лише через XPC."
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Додаток Piper, розроблений [Ігорем Шевчуком](https://ihor-shevchuk.dev), ліцензований за MIT. Це окрема програма, яка взаємодіє з Audio Unit Extension лише через XPC."
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پائپر ایپ، جسے [Ihor Shevchuk](https://ihor-shevchuk.dev) نے تیار کیا ہے، MIT کے تحت لائسنس یافتہ ہے۔ یہ ایک الگ پروگرام ہے اور صرف XPC کے ذریعے آڈیو یونٹ ایکسٹینشن کے ساتھ بات چیت کرتا ہے۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پائپر ایپ، جسے [Ihor Shevchuk](https://ihor-shevchuk.dev) نے تیار کیا ہے، MIT کے تحت لائسنس یافتہ ہے۔ یہ ایک الگ پروگرام ہے اور صرف XPC کے ذریعے آڈیو یونٹ ایکسٹینشن کے ساتھ بات چیت کرتا ہے۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper App 是由 [Ihor Shevchuk](https://ihor-shevchuk.dev) 开发的，是在 MIT 下授权的。这是一个单独的程序，仅通过 XPC 与音频设备扩展进行通信。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper App 是由 [Ihor Shevchuk](https://ihor-shevchuk.dev) 开发的，是在 MIT 下授权的。这是一个单独的程序，仅通过 XPC 与音频设备扩展进行通信。"
           }
         }
       }
     },
-    "license_piper_description": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper هو محرك نطق عصبي سريع ومفتوح المصدر طوره مجتمع OHF-Voice."
+    "license_piper_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper هو محرك نطق عصبي سريع ومفتوح المصدر طوره مجتمع OHF-Voice."
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper হল একটি দ্রুত, ওপেন-সোর্স নিউরাল টেক্সট-টু-স্পিচ ইঞ্জিন যা OHF-Voice সম্প্রদায় দ্বারা তৈরি করা হয়েছে।"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper হল একটি দ্রুত, ওপেন-সোর্স নিউরাল টেক্সট-টু-স্পিচ ইঞ্জিন যা OHF-Voice সম্প্রদায় দ্বারা তৈরি করা হয়েছে।"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper ist eine schnelle Open-Source-Neural-Text-to-Speech-Engine, die von der OHF-Voice-Community entwickelt wurde."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper ist eine schnelle Open-Source-Neural-Text-to-Speech-Engine, die von der OHF-Voice-Community entwickelt wurde."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper is a fast, open-source neural text-to-speech engine developed by the OHF-Voice community."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper is a fast, open-source neural text-to-speech engine developed by the OHF-Voice community."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper es un motor de texto a voz neuronal rápido y de código abierto desarrollado por la comunidad OHF-Voice."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper es un motor de texto a voz neuronal rápido y de código abierto desarrollado por la comunidad OHF-Voice."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper est un moteur de synthèse vocale neuronale rapide et open source développé par la communauté OHF-Voice."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper est un moteur de synthèse vocale neuronale rapide et open source développé par la communauté OHF-Voice."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "पाइपर एक तेज़, ओपन-सोर्स न्यूरल टेक्स्ट-टू-स्पीच इंजन है जिसे OHF-Voice समुदाय द्वारा विकसित किया गया है।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "पाइपर एक तेज़, ओपन-सोर्स न्यूरल टेक्स्ट-टू-स्पीच इंजन है जिसे OHF-Voice समुदाय द्वारा विकसित किया गया है।"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A Piper egy gyors, nyílt forráskódú neurális szövegfelolvasó motor, amelyet az OHF-Voice közösség fejlesztett ki."
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A Piper egy gyors, nyílt forráskódú neurális szövegfelolvasó motor, amelyet az OHF-Voice közösség fejlesztett ki."
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper adalah mesin text-to-speech saraf sumber terbuka yang cepat yang dikembangkan oleh komunitas OHF-Voice."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper adalah mesin text-to-speech saraf sumber terbuka yang cepat yang dikembangkan oleh komunitas OHF-Voice."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper è un motore di sintesi vocale neurale veloce e open source sviluppato dalla comunità OHF-Voice."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper è un motore di sintesi vocale neurale veloce e open source sviluppato dalla comunità OHF-Voice."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper は、OHF-Voice コミュニティによって開発された高速でオープンソースのニューラル テキスト読み上げエンジンです。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper は、OHF-Voice コミュニティによって開発された高速でオープンソースのニューラル テキスト読み上げエンジンです。"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper is een snelle, open-source neurale tekst-naar-spraak-engine ontwikkeld door de OHF-Voice community."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper is een snelle, open-source neurale tekst-naar-spraak-engine ontwikkeld door de OHF-Voice community."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper to szybki, otwartoźródłowy, neuronowy silnik TTS opracowany przez społeczność OHF-Voice."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper to szybki, otwartoźródłowy, neuronowy silnik TTS opracowany przez społeczność OHF-Voice."
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper är en snabb röstmotor för text-till-tal baserad på neurala nätverk med öppen källkod, utvecklad av OHF-Voice-communityn."
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper är en snabb röstmotor för text-till-tal baserad på neurala nätverk med öppen källkod, utvecklad av OHF-Voice-communityn."
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O Piper é um mecanismo de conversão de texto em fala neural rápido e de código aberto desenvolvido pela comunidade OHF-Voice."
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O Piper é um mecanismo de conversão de texto em fala neural rápido e de código aberto desenvolvido pela comunidade OHF-Voice."
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper, OHF-Voice topluluğu tarafından geliştirilen hızlı, açık kaynaklı bir sinirsel metinden konuşmaya motorudur."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper, OHF-Voice topluluğu tarafından geliştirilen hızlı, açık kaynaklı bir sinirsel metinden konuşmaya motorudur."
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper — це швидкий двигун синтезу мовлення, розроблений OHF-Voice community. з відкритим кодом."
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper — це швидкий двигун синтезу мовлення, розроблений OHF-Voice community. з відкритим кодом."
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پائپر ایک تیز، اوپن سورس نیورل ٹیکسٹ ٹو اسپیچ انجن ہے جسے OHF-Voice کمیونٹی نے تیار کیا ہے۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پائپر ایک تیز، اوپن سورس نیورل ٹیکسٹ ٹو اسپیچ انجن ہے جسے OHF-Voice کمیونٹی نے تیار کیا ہے۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper是一个由OHF-Voice 社区开发的快速开放源码文字转语音引擎。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper是一个由OHF-Voice 社区开发的快速开放源码文字转语音引擎。"
           }
         }
       }
     },
-    "model": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نموذج"
+    "model" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نموذج"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "মডেল"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "মডেল"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modell"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modell"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Model"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Model"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modelo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modelo"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modèle"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modèle"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "मॉडल"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "मॉडल"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modell"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modell"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Model"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Model"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modello"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modello"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "モデル"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "モデル"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Model"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Model"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Model"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Model"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modelo"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modelo"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modell"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modell"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Model"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Model"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Модель"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Модель"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اے آئی ماڈل"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اے آئی ماڈل"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "模型"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模型"
           }
         }
       }
     },
-    "no_voices": {
-      "comment": "A placeholder text to display when a language has no available voices.",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لا توجد أصوات متاحة"
+    "no_voices" : {
+      "comment" : "A placeholder text to display when a language has no available voices.",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا توجد أصوات متاحة"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "কোনো ভয়েস উপলব্ধ নেই"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "কোনো ভয়েস উপলব্ধ নেই"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keine Stimmen verfügbar"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Stimmen verfügbar"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No voices available"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No voices available"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No hay voces disponibles"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay voces disponibles"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aucune voix disponible"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune voix disponible"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कोई आवाज़ उपलब्ध नहीं है"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कोई आवाज़ उपलब्ध नहीं है"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nem állnak rendelkezésre hangok"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nem állnak rendelkezésre hangok"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tidak ada suara yang tersedia"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak ada suara yang tersedia"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nessuna voce disponibile"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna voce disponibile"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "利用可能な音声はありません"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "利用可能な音声はありません"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Geen stemmen beschikbaar"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geen stemmen beschikbaar"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Brak dostępnych głosów"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brak dostępnych głosów"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Inga röster tillgängliga"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inga röster tillgängliga"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nenhuma voz disponível"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhuma voz disponível"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kullanılabilir ses yok"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kullanılabilir ses yok"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Голосів немає"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Голосів немає"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کوئی آوازیں دستیاب نہیں ہیں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کوئی آوازیں دستیاب نہیں ہیں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "没有可用的声音"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有可用的声音"
           }
         }
       }
     },
-    "no_voices_message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**لم يتم تثبيت أي أصوات بعد.**\nاستخدم زر **تحميل نموذج الصوت** أدناه لإضافة صوت."
+    "no_voices_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**لم يتم تثبيت أي أصوات بعد.**\nاستخدم زر **تحميل نموذج الصوت** أدناه لإضافة صوت."
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**এখনো কোনো ভয়েস ইনস্টল করা হয়নি।**\nএকটি ভয়েস যোগ করতে নিচের **ভয়েস মডেল ডাউনলোড করুন** বোতামটি ব্যবহার করুন।"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**এখনো কোনো ভয়েস ইনস্টল করা হয়নি।**\nএকটি ভয়েস যোগ করতে নিচের **ভয়েস মডেল ডাউনলোড করুন** বোতামটি ব্যবহার করুন।"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Es sind noch keine Stimmen installiert.**\nNutze die Schaltfläche **Sprachmodell herunterladen** unten, um eine Stimme hinzuzufügen."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Es sind noch keine Stimmen installiert.**\nNutze die Schaltfläche **Sprachmodell herunterladen** unten, um eine Stimme hinzuzufügen."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**No voices are installed yet.**\nUse the **Download Voice Model** button below to add a voice."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**No voices are installed yet.**\nUse the **Download Voice Model** button below to add a voice."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Aún no hay voces instaladas.**\nUsa el botón **Descargar modelo de voz** de abajo para añadir una voz."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Aún no hay voces instaladas.**\nUsa el botón **Descargar modelo de voz** de abajo para añadir una voz."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Aucune voix n'est installée.**\nUtilisez le bouton **Télécharger le modèle de voix** ci-dessous pour ajouter une voix."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Aucune voix n'est installée.**\nUtilisez le bouton **Télécharger le modèle de voix** ci-dessous pour ajouter une voix."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**अभी तक कोई आवाज़ इंस्टॉल नहीं की गई है।**\nआवाज़ जोड़ने के लिए नीचे दिए गए **वॉयस मॉडल डाउनलोड करें** बटन का उपयोग करें।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**अभी तक कोई आवाज़ इंस्टॉल नहीं की गई है।**\nआवाज़ जोड़ने के लिए नीचे दिए गए **वॉयस मॉडल डाउनलोड करें** बटन का उपयोग करें।"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Még nincsenek hangok telepítve.**\nHang hozzáadásához használja az alábbi **Hangmodell letöltése** gombot."
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Még nincsenek hangok telepítve.**\nHang hozzáadásához használja az alábbi **Hangmodell letöltése** gombot."
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Belum ada suara yang diinstal.**\nGunakan tombol **Unduh Model Suara** di bawah ini untuk menambahkan suara."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Belum ada suara yang diinstal.**\nGunakan tombol **Unduh Model Suara** di bawah ini untuk menambahkan suara."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Nessuna voce ancora installata.**\nUsa il pulsante **Scarica modello vocale** qui sotto per aggiungere una voce."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Nessuna voce ancora installata.**\nUsa il pulsante **Scarica modello vocale** qui sotto per aggiungere una voce."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**音声がまだインストールされていません。**\n下の **音声モデルをダウンロード** ボタンを使用して音声を追加してください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**音声がまだインストールされていません。**\n下の **音声モデルをダウンロード** ボタンを使用して音声を追加してください。"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Er zijn nog geen stemmen geïnstalleerd.**\nGebruik de knop **Download spraakmodel** hieronder om een stem toe te voegen."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Er zijn nog geen stemmen geïnstalleerd.**\nGebruik de knop **Download spraakmodel** hieronder om een stem toe te voegen."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Żadne głosy nie są jeszcze zainstalowane.**\nUżyj przycisku **Pobierz model głosu** poniżej, aby dodać głos."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Żadne głosy nie są jeszcze zainstalowane.**\nUżyj przycisku **Pobierz model głosu** poniżej, aby dodać głos."
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Inga röster är installerade än.**\nAnvänd knappen **Ladda ner röstmodell** nedan för att lägga till en röst."
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Inga röster är installerade än.**\nAnvänd knappen **Ladda ner röstmodell** nedan för att lägga till en röst."
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Nenhuma voz está instalada ainda.**\nUse o botão **Baixar Modelo de Voz** abaixo para adicionar uma voz."
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Nenhuma voz está instalada ainda.**\nUse o botão **Baixar Modelo de Voz** abaixo para adicionar uma voz."
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Henüz hiçbir ses yüklenmedi.**\nBir ses eklemek için aşağıdaki **Ses Modelini İndir** düğmesini kullanın."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Henüz hiçbir ses yüklenmedi.**\nBir ses eklemek için aşağıdaki **Ses Modelini İndir** düğmesini kullanın."
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**Жодного голосу ще не встановлено.**  \nЩоб додати голос, скористайтеся кнопкою **Завантажити голосову модель** нижче."
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Жодного голосу ще не встановлено.**  \nЩоб додати голос, скористайтеся кнопкою **Завантажити голосову модель** нижче."
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**ابھی تک کوئی آوازیں انسٹال نہیں ہیں۔**\nآواز شامل کرنے کے لیے نیچے **وائس ماڈل ڈاؤن لوڈ کریں** بٹن کا استعمال کریں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**ابھی تک کوئی آوازیں انسٹال نہیں ہیں۔**\nآواز شامل کرنے کے لیے نیچے **وائس ماڈل ڈاؤن لوڈ کریں** بٹن کا استعمال کریں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "**尚未安装声音。**\n使用下面的 **下载语音模型** 按钮添加语音。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**尚未安装声音。**\n使用下面的 **下载语音模型** 按钮添加语音。"
           }
         }
       }
     },
-    "ok": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "موافق"
+    "ok" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "موافق"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ঠিক আছে"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ঠিক আছে"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ok"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ok"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aceptar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aceptar"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ठीक है"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ठीक है"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Oke"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oke"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ok"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ok"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamam"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamam"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Гаразд"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Гаразд"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ٹھیک ہے"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ٹھیک ہے"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "好的"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "好的"
           }
         }
       }
     },
-    "onnx_file": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ملف ONNX"
+    "onnx_file" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ملف ONNX"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ONNX ফাইল"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ONNX ফাইল"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ONNX-Datei"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ONNX-Datei"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ONNX File"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ONNX File"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Archivo ONNX"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archivo ONNX"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fichier ONNX"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fichier ONNX"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ONNX फ़ाइल"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ONNX फ़ाइल"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ONNX fájl"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ONNX fájl"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Berkas ONNX"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Berkas ONNX"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File ONNX"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "File ONNX"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ONNX ファイル"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ONNX ファイル"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ONNX-bestand"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ONNX-bestand"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Plik ONNX"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plik ONNX"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ONNX-fil"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ONNX-fil"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arquivo ONNX"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arquivo ONNX"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ONNX Dosyası"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ONNX Dosyası"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Файл ONNX"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Файл ONNX"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ONNX فائل"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ONNX فائل"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ONNX 文件"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ONNX 文件"
           }
         }
       }
     },
-    "piper_app_name": {
-      "comment": "The title of the main view.",
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper"
+    "piper_app_name" : {
+      "comment" : "The title of the main view.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "पाइपर"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "पाइपर"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piper"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piper"
           }
         }
       }
     },
-    "play_sample": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تشغيل عينة"
+    "play_sample" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تشغيل عينة"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "নমুনা প্লে করুন"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "নমুনা প্লে করুন"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beispiel abspielen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beispiel abspielen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Play Sample"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Play Sample"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reproducir muestra"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reproducir muestra"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lire l'échantillon"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lire l'échantillon"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "नमूना बजाएं"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "नमूना बजाएं"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minta lejátszása"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minta lejátszása"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Putar Sampel"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Putar Sampel"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Riproduci campione"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riproduci campione"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サンプルを再生"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サンプルを再生"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Speel voorbeeld af"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speel voorbeeld af"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Odtwórz próbkę"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odtwórz próbkę"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Spela prov"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spela prov"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reproduzir Amostra"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reproduzir Amostra"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Örnek Oynat"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Örnek Oynat"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Відтворити приклад"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відтворити приклад"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نمونہ کھیلیں"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نمونہ کھیلیں"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "播放示例"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放示例"
           }
         }
       }
     },
-    "quality": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الجودة"
+    "quality" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الجودة"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "গুণমান"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "গুণমান"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Qualität"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Qualität"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quality"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quality"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Calidad"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calidad"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Qualité"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Qualité"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "गुणवत्ता"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "गुणवत्ता"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minőség"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minőség"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kualitas"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kualitas"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Qualità"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Qualità"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "品質"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "品質"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kwaliteit"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kwaliteit"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jakość"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jakość"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kvalitet"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kvalitet"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Qualidade"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Qualidade"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kalite"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kalite"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Якість"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Якість"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "معیار"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "معیار"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "质量"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "质量"
           }
         }
       }
     },
-    "sample_rate": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "معدل العينة"
+    "sample_rate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "معدل العينة"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "স্যাম্পল রেট"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "স্যাম্পল রেট"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abtastrate"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abtastrate"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sample Rate"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sample Rate"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Frecuencia de muestreo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frecuencia de muestreo"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taux d'échantillonnage"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taux d'échantillonnage"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सैंपल रेट"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सैंपल रेट"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mintavételezési gyakoriság"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mintavételezési gyakoriság"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Laju Sampel"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laju Sampel"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Frequenza di campionamento"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frequenza di campionamento"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サンプリングレート"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サンプリングレート"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Samplefrequentie"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Samplefrequentie"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Częstotliwość próbkowania"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Częstotliwość próbkowania"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Samplingsfrekvens"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Samplingsfrekvens"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taxa de Amostragem"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taxa de Amostragem"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Örnekleme Hızı"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Örnekleme Hızı"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Частота"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Частота"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نمونہ کی شرح"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نمونہ کی شرح"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "采样率"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "采样率"
           }
         }
       }
     },
-    "sample_text": {
-      "comment": "A text field for entering sample text.",
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نص العينة"
+    "sample_text" : {
+      "comment" : "A text field for entering sample text.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نص العينة"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "নমুনা টেক্সট"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "নমুনা টেক্সট"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beispieltext"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beispieltext"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sample Text"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sample Text"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Texto de muestra"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Texto de muestra"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Texte d'exemple"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Texte d'exemple"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "नमूना पाठ"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "नमूना पाठ"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mintaszöveg"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mintaszöveg"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Teks Sampel"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Teks Sampel"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Testo di esempio"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Testo di esempio"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サンプルテキスト"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サンプルテキスト"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voorbeeldtekst"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voorbeeldtekst"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Przykładowy tekst"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przykładowy tekst"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exempeltext"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exempeltext"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Texto de Amostra"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Texto de Amostra"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Örnek Metin"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Örnek Metin"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Текст прикладу"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Текст прикладу"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نمونہ متن"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نمونہ متن"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "示例文本"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "示例文本"
           }
         }
       }
     },
-    "sample_text: %@": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نص العينة: %1$@"
+    "sample_text: %@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نص العينة: %1$@"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "নমুনা টেক্সট: %1$@"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "নমুনা টেক্সট: %1$@"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beispieltext: %1$@"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beispieltext: %1$@"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sample Text: %1$@"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sample Text: %1$@"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Texto de muestra: %1$@"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Texto de muestra: %1$@"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Texte d'exemple : %1$@"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Texte d'exemple : %1$@"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "नमूना पाठ: %1$@"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "नमूना पाठ: %1$@"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mintaszöveg: %1$@"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mintaszöveg: %1$@"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Teks Sampel: %1$@"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Teks Sampel: %1$@"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Testo di esempio: %1$@"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Testo di esempio: %1$@"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サンプルテキスト: %1$@"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サンプルテキスト: %1$@"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voorbeeldtekst: %1$@"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voorbeeldtekst: %1$@"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Przykładowy tekst: %1$@"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przykładowy tekst: %1$@"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exempeltext: %1$@"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exempeltext: %1$@"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Texto de Amostra: %1$@"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Texto de Amostra: %1$@"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Örnek Metin: %1$@"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Örnek Metin: %1$@"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Приклад: %1$@"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Приклад: %1$@"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نمونہ متن: %1$@"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نمونہ متن: %1$@"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "示例文本： %1$@"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "示例文本： %1$@"
           }
         }
       }
     },
-    "select_json": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اختر JSON"
+    "select_json" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اختر JSON"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "JSON নির্বাচন করুন"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON নির্বাচন করুন"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "JSON auswählen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON auswählen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select JSON"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select JSON"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seleccionar JSON"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar JSON"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sélectionner JSON"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionner JSON"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "JSON चुनें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON चुनें"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "JSON kiválasztása"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON kiválasztása"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pilih JSON"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih JSON"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seleziona JSON"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleziona JSON"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "JSON を選択"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON を選択"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selecteer JSON"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecteer JSON"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wybierz JSON"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wybierz JSON"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Välj JSON"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Välj JSON"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selecionar JSON"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecionar JSON"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "JSON'u seçin"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON'u seçin"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Виберіть JSON"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виберіть JSON"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "JSON کو منتخب کریں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON کو منتخب کریں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "选择 JSON"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择 JSON"
           }
         }
       }
     },
-    "select_model": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اختر النموذج"
+    "select_model" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اختر النموذج"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "মডেল নির্বাচন করুন"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "মডেল নির্বাচন করুন"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modell auswählen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modell auswählen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select Model"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select Model"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seleccionar modelo"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar modelo"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sélectionner le modèle"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionner le modèle"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "मॉडल चुनें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "मॉडल चुनें"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modell kiválasztása"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modell kiválasztása"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pilih Model"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih Model"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seleziona modello"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleziona modello"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "モデルを選択"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "モデルを選択"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selecteer model"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecteer model"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wybierz model"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wybierz model"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Välj modell"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Välj modell"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selecionar Modelo"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecionar Modelo"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Model Seç"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Model Seç"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Виберіть модель"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виберіть модель"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ماڈل منتخب کریں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ماڈل منتخب کریں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "选择模型"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择模型"
           }
         }
       }
     },
-    "share_feedback": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مشاركة الملاحظات"
+    "share_feedback" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مشاركة الملاحظات"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ফিডব্যাক শেয়ার করুন"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ফিডব্যাক শেয়ার করুন"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feedback teilen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feedback teilen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share Feedback"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share Feedback"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Compartir comentarios"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartir comentarios"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Partager un avis"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Partager un avis"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "प्रतिक्रिया साझा करें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "प्रतिक्रिया साझा करें"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Visszajelzés küldése"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visszajelzés küldése"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bagikan Umpan Balik"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bagikan Umpan Balik"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Condividi feedback"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Condividi feedback"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フィードバックを共有"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フィードバックを共有"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deel feedback"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deel feedback"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wyślij opinię"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyślij opinię"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dela feedback"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dela feedback"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Compartilhar Feedback"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartilhar Feedback"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Geri Bildirim Paylaş"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geri Bildirim Paylaş"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Поділитися Відгуком"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поділитися Відгуком"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فیڈ بیک شیئر کریں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فیڈ بیک شیئر کریں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "分享反馈"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分享反馈"
           }
         }
       }
     },
-    "speaker": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "المتحدث"
+    "speaker" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "المتحدث"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "স্পিকার"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "স্পিকার"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sprecher"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprecher"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Speaker"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speaker"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Locutor"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Locutor"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Interlocuteur"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interlocuteur"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "वक्ता"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "वक्ता"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beszélő"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beszélő"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Speaker"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speaker"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voce"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voce"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "話者"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "話者"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Spreker"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spreker"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Głośnik"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Głośnik"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Röst"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Röst"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Locutor"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Locutor"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hoparlör"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hoparlör"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Голос"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Голос"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "متکلم"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "متکلم"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "扬声器"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "扬声器"
           }
         }
       }
     },
-    "stop": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إيقاف"
+    "stop" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إيقاف"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "থামুন"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "থামুন"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stopp"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stopp"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stop"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Detener"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detener"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arrêter"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrêter"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "रोकें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "रोकें"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stop"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Berhenti"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Berhenti"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stop"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "停止"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stop"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stop"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stoppa"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stoppa"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parar"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parar"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Durdur"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Durdur"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Зупинити"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зупинити"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "رک جاؤ"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رک جاؤ"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "停止"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止"
           }
         }
       }
     },
-    "stop_playing": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إيقاف التشغيل"
+    "stop_playing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إيقاف التشغيل"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "প্লে করা বন্ধ করুন"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "প্লে করা বন্ধ করুন"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wiedergabe stoppen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiedergabe stoppen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stop Playing"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop Playing"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Detener reproducción"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detener reproducción"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arrêter la lecture"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrêter la lecture"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "बजाना बंद करें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "बजाना बंद करें"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lejátszás leállítása"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lejátszás leállítása"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Berhenti Memutar"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Berhenti Memutar"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Interrompi riproduzione"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interrompi riproduzione"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "再生を停止"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再生を停止"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stop afspelen"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop afspelen"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zatrzymaj odtwarzanie"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zatrzymaj odtwarzanie"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sluta spela"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sluta spela"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parar Reprodução"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parar Reprodução"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Oynatmayı Durdur"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oynatmayı Durdur"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Зупинити відтворення"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зупинити відтворення"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کھیلنا بند کرو"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کھیلنا بند کرو"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "停止播放"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止播放"
           }
         }
       }
     },
-    "uninstall_button": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إزالة"
+    "uninstall_button" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إزالة"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "সরান"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "সরান"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entfernen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entfernen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remove"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eliminar"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Supprimer"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "हटाएं"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "हटाएं"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eltávolítás"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eltávolítás"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hapus"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hapus"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rimuovi"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rimuovi"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "削除"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verwijder"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verwijder"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usuń"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuń"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ta bort"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ta bort"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remover"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remover"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kaldır"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaldır"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Видалити"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Видалити"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ہٹا دیں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ہٹا دیں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "删除"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除"
           }
         }
       }
     },
-    "uninstall_voice": {
-      "comment": "A button label that uninstalls the voice assistant.",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إزالة نموذج الصوت"
+    "uninstall_voice" : {
+      "comment" : "A button label that uninstalls the voice assistant.",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إزالة نموذج الصوت"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ভয়েস মডেল সরান"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ভয়েস মডেল সরান"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sprachmodell entfernen"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprachmodell entfernen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remove Voice Model"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Voice Model"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eliminar modelo de voz"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar modelo de voz"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Supprimer le modèle de voix"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer le modèle de voix"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "वॉयस मॉडल हटाएं"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "वॉयस मॉडल हटाएं"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hangmodell eltávolítása"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hangmodell eltávolítása"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hapus Model Suara"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hapus Model Suara"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rimuovi modello vocale"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rimuovi modello vocale"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "音声モデルを削除"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音声モデルを削除"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verwijder spraakmodel"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verwijder spraakmodel"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usuń model głosu"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuń model głosu"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ta bort röstmodell"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ta bort röstmodell"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remover Modelo de Voz"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remover Modelo de Voz"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ses Modelini Kaldır"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ses Modelini Kaldır"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Видалити голосову модель"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Видалити голосову модель"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "وائس ماڈل کو ہٹا دیں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "وائس ماڈل کو ہٹا دیں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "删除语音模型"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除语音模型"
           }
         }
       }
     },
-    "update_model_in_app": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "استيراد نموذج من الملفات"
+    "update_model_in_app" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "استيراد نموذج من الملفات"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ফাইল থেকে মডেল ইমপোর্ট করুন"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ফাইল থেকে মডেল ইমপোর্ট করুন"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modell aus Dateien importieren"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modell aus Dateien importieren"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Import Model from Files"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Import Model from Files"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Importar modelo desde archivos"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importar modelo desde archivos"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Importer le modèle depuis les fichiers"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importer le modèle depuis les fichiers"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "फ़ाइलों से मॉडल आयात करें"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "फ़ाइलों से मॉडल आयात करें"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modell importálása fájlokból"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modell importálása fájlokból"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impor Model dari Berkas"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impor Model dari Berkas"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Importa modello da file"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importa modello da file"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ファイルからモデルをインポート"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイルからモデルをインポート"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Importeer model uit bestanden"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importeer model uit bestanden"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Importuj model z plików"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importuj model z plików"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Importera modell från filer"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importera modell från filer"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Importar Modelo de Arquivos"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importar Modelo de Arquivos"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dosyalardan Model İçe Aktar"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dosyalardan Model İçe Aktar"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Імпортувати з файлів"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Імпортувати з файлів"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فائلوں سے ماڈل درآمد کریں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فائلوں سے ماڈل درآمد کریں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "从文件导入模型"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从文件导入模型"
           }
         }
       }
     },
-    "version": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الإصدار"
+    "version" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الإصدار"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "সংস্করণ"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "সংস্করণ"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versión"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versión"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "वर्शन"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "वर्शन"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verzió"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verzió"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versi"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versi"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versione"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versione"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "バージョン"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バージョン"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versie"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versie"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wersja"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wersja"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versão"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versão"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sürüm"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sürüm"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Версія"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Версія"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ورژن"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ورژن"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "版本"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版本"
           }
         }
       }
     },
-    "voice_loading_progress_%@": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تقدم التحميل %@%"
+    "voice_loading_progress_%@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تقدم التحميل %@%"
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ডাউনলোডের অগ্রগতি %@%"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ডাউনলোডের অগ্রগতি %@%"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download-Fortschritt %@%"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download-Fortschritt %@%"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "downloading progress %@%"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "downloading progress %@%"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "progreso de descarga %@%"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "progreso de descarga %@%"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "progression du téléchargement %@%"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "progression du téléchargement %@%"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "डाउनलोडिंग प्रगति %@%"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "डाउनलोडिंग प्रगति %@%"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "letöltési folyamat %@%"
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "letöltési folyamat %@%"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "progres mengunduh %@%"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "progres mengunduh %@%"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "progresso download %@%"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "progresso download %@%"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ダウンロードの進行状況 %@%"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロードの進行状況 %@%"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "download voortgang %@%"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "download voortgang %@%"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "postęp pobierania %@%"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "postęp pobierania %@%"
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "nedladdningsframsteg %@%"
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "nedladdningsframsteg %@%"
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "progresso do download %@%"
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "progresso do download %@%"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "indirme ilerlemesi %@%"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "indirme ilerlemesi %@%"
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "прогрес завантаження %@%"
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "прогрес завантаження %@%"
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ڈاؤن لوڈنگ کی پیشرفت %@%"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ڈاؤن لوڈنگ کی پیشرفت %@%"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在下载进度 %@%"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在下载进度 %@%"
           }
         }
       }
     },
-    "warning_big_voice_files": {
-      "comment": "A warning message about the size of voice files.",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ملاحظة: يمكن أن تكون ملفات الصوت كبيرة. لتجنب رسوم إضافية، قم بالتحميل باستخدام Wi-Fi أو خطة بيانات غير محدودة."
+    "warning_big_voice_files" : {
+      "comment" : "A warning message about the size of voice files.",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ملاحظة: يمكن أن تكون ملفات الصوت كبيرة. لتجنب رسوم إضافية، قم بالتحميل باستخدام Wi-Fi أو خطة بيانات غير محدودة."
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "দ্রষ্টব্য: ভয়েস ফাইলগুলি বড় হতে পারে। অতিরিক্ত খরচ এড়াতে, Wi-Fi বা আনলিমিটেড ডেটা প্ল্যান ব্যবহার করে ডাউনলোড করুন।"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "দ্রষ্টব্য: ভয়েস ফাইলগুলি বড় হতে পারে। অতিরিক্ত খরচ এড়াতে, Wi-Fi বা আনলিমিটেড ডেটা প্ল্যান ব্যবহার করে ডাউনলোড করুন।"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hinweis: Sprachdateien können groß sein. Um zusätzliche Gebühren zu vermeiden, lade sie über WLAN oder einen unbegrenzten Datentarif herunter."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hinweis: Sprachdateien können groß sein. Um zusätzliche Gebühren zu vermeiden, lade sie über WLAN oder einen unbegrenzten Datentarif herunter."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Note: Voice files can be large. To avoid extra charges, download using Wi-Fi or an unlimited data plan."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Note: Voice files can be large. To avoid extra charges, download using Wi-Fi or an unlimited data plan."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nota: Los archivos de voz pueden ser grandes. Para evitar cargos adicionales, descárgalos usando Wi-Fi o un plan de datos ilimitado."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nota: Los archivos de voz pueden ser grandes. Para evitar cargos adicionales, descárgalos usando Wi-Fi o un plan de datos ilimitado."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remarque : Les fichiers vocaux peuvent être volumineux. Pour éviter des frais supplémentaires, téléchargez-les via Wi-Fi ou un forfait de données illimité."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remarque : Les fichiers vocaux peuvent être volumineux. Pour éviter des frais supplémentaires, téléchargez-les via Wi-Fi ou un forfait de données illimité."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "नोट: वॉयस फ़ाइलें बड़ी हो सकती हैं। अतिरिक्त शुल्क से बचने के लिए, वाई-फाई या असीमित डेटा प्लान का उपयोग करके डाउनलोड करें।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "नोट: वॉयस फ़ाइलें बड़ी हो सकती हैं। अतिरिक्त शुल्क से बचने के लिए, वाई-फाई या असीमित डेटा प्लान का उपयोग करके डाउनलोड करें।"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Megjegyzés: A hangfájlok mérete nagy lehet. A pluszköltségek elkerülése érdekében javasoljuk, hogy Wi-Fi-n vagy korlátlan adatforgalmi csomagon keresztül töltse le azokat."
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Megjegyzés: A hangfájlok mérete nagy lehet. A pluszköltségek elkerülése érdekében javasoljuk, hogy Wi-Fi-n vagy korlátlan adatforgalmi csomagon keresztül töltse le azokat."
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Catatan: Berkas suara bisa berukuran besar. Untuk menghindari biaya tambahan, unduh menggunakan Wi-Fi atau paket data tak terbatas."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Catatan: Berkas suara bisa berukuran besar. Untuk menghindari biaya tambahan, unduh menggunakan Wi-Fi atau paket data tak terbatas."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nota: I file vocali possono essere grandi. Per evitare costi aggiuntivi, scarica utilizzando il Wi-Fi o un piano dati illimitato."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nota: I file vocali possono essere grandi. Per evitare costi aggiuntivi, scarica utilizzando il Wi-Fi o un piano dati illimitato."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "注意：音声ファイルは大きくなる場合があります。追加料金を避けるために、Wi-Fi または無制限のデータプランを使用してダウンロードしてください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "注意：音声ファイルは大きくなる場合があります。追加料金を避けるために、Wi-Fi または無制限のデータプランを使用してダウンロードしてください。"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opmerking: Spraakbestanden kunnen groot zijn. Om extra kosten te vermijden, download je via wifi of een onbeperkt data-abonnement."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opmerking: Spraakbestanden kunnen groot zijn. Om extra kosten te vermijden, download je via wifi of een onbeperkt data-abonnement."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uwaga: Pliki głosowe mogą być duże. Aby uniknąć dodatkowych opłat, pobieraj przez Wi-Fi lub z nielimitowanym pakietem danych."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uwaga: Pliki głosowe mogą być duże. Aby uniknąć dodatkowych opłat, pobieraj przez Wi-Fi lub z nielimitowanym pakietem danych."
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Obs: Röstfiler kan vara stora. För att undvika extra kostnader, ladda ner via Wi-Fi eller ett obegränsat datapaket."
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obs: Röstfiler kan vara stora. För att undvika extra kostnader, ladda ner via Wi-Fi eller ett obegränsat datapaket."
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nota: Arquivos de voz podem ser grandes. Para evitar cobranças extras, baixe usando Wi-Fi ou um plano de dados ilimitado."
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nota: Arquivos de voz podem ser grandes. Para evitar cobranças extras, baixe usando Wi-Fi ou um plano de dados ilimitado."
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not: Ses dosyaları büyük olabilir. Ek ücretlerden kaçınmak için Wi-Fi veya sınırsız veri planı ile indirin."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not: Ses dosyaları büyük olabilir. Ek ücretlerden kaçınmak için Wi-Fi veya sınırsız veri planı ile indirin."
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Примітка: голосові файли можуть бути великими. Щоб уникнути додаткових витрат, завантажуйте через Wi-Fi або безлімітний тариф."
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Примітка: голосові файли можуть бути великими. Щоб уникнути додаткових витрат, завантажуйте через Wi-Fi або безлімітний тариф."
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نوٹ: صوتی فائلیں بڑی ہو سکتی ہیں۔ اضافی چارجز سے بچنے کے لیے، Wi-Fi یا لامحدود ڈیٹا پلان کا استعمال کرکے ڈاؤن لوڈ کریں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نوٹ: صوتی فائلیں بڑی ہو سکتی ہیں۔ اضافی چارجز سے بچنے کے لیے، Wi-Fi یا لامحدود ڈیٹا پلان کا استعمال کرکے ڈاؤن لوڈ کریں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "注意：语音文件可能大。为了避免额外费用，请使用 Wi-Fi 或无限数据计划下载。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "注意：语音文件可能大。为了避免额外费用，请使用 Wi-Fi 或无限数据计划下载。"
           }
         }
       }
     },
-    "warning_not_tested_voices": {
-      "comment": "A warning displayed below the list of available languages, reminding users that some voices have not been tested.",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "هذه الأصوات مرفوعة من قبل المجتمع وقد لا تكون مختبرة بالكامل. قد تكون بعض الملفات غير مكتملة أو تتصرف بشكل غير متوقع. التحميل والتثبيت على مسؤوليتك الخاصة."
+    "warning_not_tested_voices" : {
+      "comment" : "A warning displayed below the list of available languages, reminding users that some voices have not been tested.",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هذه الأصوات مرفوعة من قبل المجتمع وقد لا تكون مختبرة بالكامل. قد تكون بعض الملفات غير مكتملة أو تتصرف بشكل غير متوقع. التحميل والتثبيت على مسؤوليتك الخاصة."
           }
         },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "এই ভয়েসগুলি সম্প্রদায়-আপলোড করা এবং সম্পূর্ণরূপে পরীক্ষা করা নাও হতে পারে। কিছু ফাইল অসম্পূর্ণ হতে পারে বা অপ্রত্যাশিত আচরণ করতে পারে। আপনার নিজ দায়িত্বে ডাউনলোড এবং ইনস্টল করুন।"
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "এই ভয়েসগুলি সম্প্রদায়-আপলোড করা এবং সম্পূর্ণরূপে পরীক্ষা করা নাও হতে পারে। কিছু ফাইল অসম্পূর্ণ হতে পারে বা অপ্রত্যাশিত আচরণ করতে পারে। আপনার নিজ দায়িত্বে ডাউনলোড এবং ইনস্টল করুন।"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Diese Stimmen wurden von der Community hochgeladen und sind möglicherweise nicht vollständig getestet. Einige Dateien können unvollständig sein oder sich unerwartet verhalten. Download und Installation auf eigene Gefahr."
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Stimmen wurden von der Community hochgeladen und sind möglicherweise nicht vollständig getestet. Einige Dateien können unvollständig sein oder sich unerwartet verhalten. Download und Installation auf eigene Gefahr."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "These voices are community-uploaded and may not be fully tested. Some files may be incomplete or behave unexpectedly. Download and install at your own risk."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "These voices are community-uploaded and may not be fully tested. Some files may be incomplete or behave unexpectedly. Download and install at your own risk."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estas voces han sido subidas por la comunidad y es posible que no se hayan probado por completo. Algunos archivos pueden estar incompletos o comportarse de forma inesperada. Descarga e instala bajo tu propia responsabilidad."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estas voces han sido subidas por la comunidad y es posible que no se hayan probado por completo. Algunos archivos pueden estar incompletos o comportarse de forma inesperada. Descarga e instala bajo tu propia responsabilidad."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ces voix sont téléchargées par la communauté et peuvent ne pas être entièrement testées. Certains fichiers peuvent être incomplets ou se comporter de manière inattendue. Téléchargez et installez à vos propres risques."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ces voix sont téléchargées par la communauté et peuvent ne pas être entièrement testées. Certains fichiers peuvent être incomplets ou se comporter de manière inattendue. Téléchargez et installez à vos propres risques."
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ये आवाज़ें समुदाय द्वारा अपलोड की गई हैं और हो सकता है कि इनका पूरी तरह से परीक्षण न किया गया हो। कुछ फ़ाइलें अधूरी हो सकती हैं या अप्रत्याशित व्यवहार कर सकती हैं। अपने जोखिम पर डाउनलोड और इंस्टॉल करें।"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ये आवाज़ें समुदाय द्वारा अपलोड की गई हैं और हो सकता है कि इनका पूरी तरह से परीक्षण न किया गया हो। कुछ फ़ाइलें अधूरी हो सकती हैं या अप्रत्याशित व्यवहार कर सकती हैं। अपने जोखिम पर डाउनलोड और इंस्टॉल करें।"
           }
         },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ezeket a hangokat a közösség töltötte fel, és előfordulhat, hogy nem tesztelték őket teljes körűen. Egyes fájlok hiányosak lehetnek, vagy váratlanul működhetnek. Letöltés és telepítés saját felelősségre."
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ezeket a hangokat a közösség töltötte fel, és előfordulhat, hogy nem tesztelték őket teljes körűen. Egyes fájlok hiányosak lehetnek, vagy váratlanul működhetnek. Letöltés és telepítés saját felelősségre."
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Suara-suara ini diunggah oleh komunitas dan mungkin belum diuji sepenuhnya. Beberapa berkas mungkin tidak lengkap atau berperilaku tidak terduga. Unduh dan instal atas risiko Anda sendiri."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suara-suara ini diunggah oleh komunitas dan mungkin belum diuji sepenuhnya. Beberapa berkas mungkin tidak lengkap atau berperilaku tidak terduga. Unduh dan instal atas risiko Anda sendiri."
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Queste voci sono caricate dalla comunità e potrebbero non essere state testate completamente. Alcuni file potrebbero essere incompleti o comportarsi in modo inaspettato. Scarica e installa a tuo rischio e pericolo."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Queste voci sono caricate dalla comunità e potrebbero non essere state testate completamente. Alcuni file potrebbero essere incompleti o comportarsi in modo inaspettato. Scarica e installa a tuo rischio e pericolo."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "これらの音声はコミュニティによってアップロードされたものであり、完全にテストされていない可能性があります。一部のファイルが不完全であったり、予期しない動作をしたりする場合があります。ご自身の責任でダウンロードしてインストールしてください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "これらの音声はコミュニティによってアップロードされたものであり、完全にテストされていない可能性があります。一部のファイルが不完全であったり、予期しない動作をしたりする場合があります。ご自身の責任でダウンロードしてインストールしてください。"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deze stemmen zijn geüpload door de community en zijn mogelijk niet volledig getest. Sommige bestanden kunnen onvolledig zijn of zich onverwacht gedragen. Downloaden en installeren is op eigen risico."
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deze stemmen zijn geüpload door de community en zijn mogelijk niet volledig getest. Sommige bestanden kunnen onvolledig zijn of zich onverwacht gedragen. Downloaden en installeren is op eigen risico."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Te głosy zostały przesłane przez społeczność i mogą nie być w pełni przetestowane. Niektóre pliki mogą być niekompletne lub działać nieprawidłowo. Pobieraj i instaluj na własne ryzyko."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Te głosy zostały przesłane przez społeczność i mogą nie być w pełni przetestowane. Niektóre pliki mogą być niekompletne lub działać nieprawidłowo. Pobieraj i instaluj na własne ryzyko."
           }
         },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dessa röster är uppladdade av communityn och har kanske inte testats fullständigt. Vissa filer kan vara ofullständiga eller bete sig oväntat. Ladda ner och installera på egen risk."
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dessa röster är uppladdade av communityn och har kanske inte testats fullständigt. Vissa filer kan vara ofullständiga eller bete sig oväntat. Ladda ner och installera på egen risk."
           }
         },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estas vozes são enviadas pela comunidade e podem não estar totalmente testadas. Alguns arquivos podem estar incompletos ou se comportar de forma inesperada. Baixe e instale por sua conta e risco."
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estas vozes são enviadas pela comunidade e podem não estar totalmente testadas. Alguns arquivos podem estar incompletos ou se comportar de forma inesperada. Baixe e instale por sua conta e risco."
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bu sesler topluluk tarafından yüklenmiştir ve tamamen test edilmemiş olabilir. Bazı dosyalar eksik veya beklenmedik şekilde davranabilir. Kendi riskinizle indirin ve yükleyin."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu sesler topluluk tarafından yüklenmiştir ve tamamen test edilmemiş olabilir. Bazı dosyalar eksik veya beklenmedik şekilde davranabilir. Kendi riskinizle indirin ve yükleyin."
           }
         },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ці голоси додані спільнотою та можуть бути недостатньо протестовані. Деякі файли можуть бути неповними або працювати нестабільно. Завантажуйте та встановлюйте на свій ризик."
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ці голоси додані спільнотою та можуть бути недостатньо протестовані. Деякі файли можуть бути неповними або працювати нестабільно. Завантажуйте та встановлюйте на свій ризик."
           }
         },
-        "ur-PK": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "یہ آوازیں کمیونٹی کے ذریعے اپ لوڈ کی گئی ہیں اور ہو سکتا ہے کہ ان کا مکمل تجربہ نہ کیا جائے۔ کچھ فائلیں نامکمل ہو سکتی ہیں یا غیر متوقع طور پر برتاؤ کرتی ہیں۔ اپنی ذمہ داری پر ڈاؤن لوڈ اور انسٹال کریں۔"
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یہ آوازیں کمیونٹی کے ذریعے اپ لوڈ کی گئی ہیں اور ہو سکتا ہے کہ ان کا مکمل تجربہ نہ کیا جائے۔ کچھ فائلیں نامکمل ہو سکتی ہیں یا غیر متوقع طور پر برتاؤ کرتی ہیں۔ اپنی ذمہ داری پر ڈاؤن لوڈ اور انسٹال کریں۔"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "这些声音是社区上传的，可能不会完全测试。一些文件可能不完整或出乎意料。下载并安装您自己承担的风险。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这些声音是社区上传的，可能不会完全测试。一些文件可能不完整或出乎意料。下载并安装您自己承担的风险。"
           }
         }
       }
     },
-    "stops sample playback": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stops sample playback"
+    "download_voice_hint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Downloads this voice"
           }
         }
       }
     },
-    "loading sample": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Loading sample"
+    "language_row_hint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shows voices"
           }
         }
       }
     },
-    "plays a sample": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Plays a sample"
+    "loading_sample" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading sample"
           }
         }
       }
     },
-    "removes this voice": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Removes this voice"
+    "play_sample_hint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plays a sample"
           }
         }
       }
     },
-    "downloads this voice": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Downloads this voice"
+    "stop_playing_hint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stops sample playback"
           }
         }
       }
     },
-    "double tap for details": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Double tap for details"
+    "uninstall_voice_hint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Removes this voice"
           }
         }
       }
     },
-    "shows voices": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shows voices"
-          }
-        }
-      }
-    },
-    "downloading_percent": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld%%"
+    "voice_item_hint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Double tap for details"
           }
         }
       }
     }
   },
-  "version": "1.1"
+  "version" : "1.1"
 }

--- a/PiperApp/Resources/Localization/Localizable.xcstrings
+++ b/PiperApp/Resources/Localization/Localizable.xcstrings
@@ -1,7507 +1,7595 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "about_app" : {
-      "comment" : "A label for the \"About\" button in the main view.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "حول التطبيق"
+  "sourceLanguage": "en",
+  "strings": {
+    "about_app": {
+      "comment": "A label for the \"About\" button in the main view.",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حول التطبيق"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "অ্যাপ সম্পর্কে"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "অ্যাপ সম্পর্কে"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Über die App"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Über die App"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "About the App"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About the App"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acerca de la aplicación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acerca de la aplicación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "À propos de l'application"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "À propos de l'application"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ऐप के बारे में"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ऐप के बारे में"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Az alkalmazásról"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Az alkalmazásról"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tentang Aplikasi"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tentang Aplikasi"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informazioni sull'app"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informazioni sull'app"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリについて"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリについて"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Over de app"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Over de app"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O aplikacji"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O aplikacji"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Om appen"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Om appen"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sobre o App"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sobre o App"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uygulama Hakkında"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uygulama Hakkında"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Про Додаток"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Про Додаток"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ایپ کے بارے میں"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ایپ کے بارے میں"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关于应用程序"
-          }
-        }
-      }
-    },
-    "app_help_line_1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "قم بتثبيت صوت من قائمة **تحميل نموذج الصوت** لبدء استخدام التطبيق."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "অ্যাপটি ব্যবহার শুরু করতে **ভয়েস মডেল ডাউনলোড করুন** মেনু থেকে একটি ভয়েস ইনস্টল করুন।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installiere eine Stimme aus dem Menü **Sprachmodell herunterladen**, um die App zu nutzen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a voice from **Download Voice Model** menu to start using the app."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instala una voz desde el menú **Descargar modelo de voz** para empezar a usar la aplicación."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installez une voix à partir du menu **Télécharger le modèle de voix** pour commencer à utiliser l'application."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ऐप का उपयोग शुरू करने के लिए **वॉयस मॉडल डाउनलोड करें** मेनू से आवाज़ इंस्टॉल करें।"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A használat megkezdéséhez telepítsen egy hangot a **Hangmodell letöltése** menüből."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instal suara dari menu **Unduh Model Suara** untuk mulai menggunakan aplikasi."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installa una voce dal menu **Scarica modello vocale** per iniziare a usare l'app."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリの使用を開始するには、**音声モデルをダウンロード** メニューから音声をインストールしてください。"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installeer een stem uit het menu **Download spraakmodel** om de app te gaan gebruiken."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zainstaluj głos z menu **Pobierz model głosu**, aby rozpocząć korzystanie z aplikacji."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installera en röst från menyn **Ladda ner röstmodell** för att börja använda appen."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instale uma voz do menu **Baixar Modelo de Voz** para começar a usar o app."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uygulamayı kullanmaya başlamak için **Ses Modelini İndir** menüsünden bir ses yükleyin."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Встановіть голос за допомогою **Завантажити голосову модель**, щоб почати користуватися застосунком."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ایپ کا استعمال شروع کرنے کے لیے **ڈاؤن لوڈ وائس ماڈل** مینو سے آواز انسٹال کریں۔"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "从 **Download Voice Model** 菜单安装语音以开始使用应用程序。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关于应用程序"
           }
         }
       }
     },
-    "app_help_line_2_ios" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "انتقل إلى **الإعدادات ← تسهيلات الاستخدام ← VoiceOver ← النطق**."
+    "app_help_line_1": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قم بتثبيت صوت من قائمة **تحميل نموذج الصوت** لبدء استخدام التطبيق."
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**সেটিংস → অ্যাক্সেসিবিলিটি → ভয়েসওভার → স্পিচ**-এ যান।"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "অ্যাপটি ব্যবহার শুরু করতে **ভয়েস মডেল ডাউনলোড করুন** মেনু থেকে একটি ভয়েস ইনস্টল করুন।"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gehe zu **Einstellungen → Bedienungshilfen → VoiceOver → Sprache**."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installiere eine Stimme aus dem Menü **Sprachmodell herunterladen**, um die App zu nutzen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Go to **Settings → Accessibility → VoiceOver → Speech**."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install a voice from **Download Voice Model** menu to start using the app."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ve a **Ajustes → Accesibilidad → VoiceOver → Voz**."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instala una voz desde el menú **Descargar modelo de voz** para empezar a usar la aplicación."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allez dans **Réglages → Accessibilité → VoiceOver → Parole**."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installez une voix à partir du menu **Télécharger le modèle de voix** pour commencer à utiliser l'application."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**सेटिंग्स → एक्सेसिबिलिटी → वॉयसओवर → स्पीच** पर जाएं।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ऐप का उपयोग शुरू करने के लिए **वॉयस मॉडल डाउनलोड करें** मेनू से आवाज़ इंस्टॉल करें।"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lépjen a **Beállítások → Kisegítő lehetőségek → VoiceOver → Beszéd** menüpontba."
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A használat megkezdéséhez telepítsen egy hangot a **Hangmodell letöltése** menüből."
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buka **Pengaturan → Aksesibilitas → VoiceOver → Ucapan**."
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instal suara dari menu **Unduh Model Suara** untuk mulai menggunakan aplikasi."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vai su **Impostazioni → Accessibilità → VoiceOver → Voce**."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installa una voce dal menu **Scarica modello vocale** per iniziare a usare l'app."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**設定 → アクセシビリティ → VoiceOver → 読み上げ** に移動します。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリの使用を開始するには、**音声モデルをダウンロード** メニューから音声をインストールしてください。"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ga naar **Instellingen → Toegankelijkheid → VoiceOver → Spraak**."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installeer een stem uit het menu **Download spraakmodel** om de app te gaan gebruiken."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przejdź do **Ustawienia → Dostępność → VoiceOver → Mowa**."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zainstaluj głos z menu **Pobierz model głosu**, aby rozpocząć korzystanie z aplikacji."
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gå till **Inställningar → Hjälpmedel → VoiceOver → Tal**."
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installera en röst från menyn **Ladda ner röstmodell** för att börja använda appen."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vá em **Ajustes → Acessibilidade → VoiceOver → Fala**."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instale uma voz do menu **Baixar Modelo de Voz** para começar a usar o app."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Ayarlar → Erişilebilirlik → VoiceOver → Konuşma** bölümüne gidin."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uygulamayı kullanmaya başlamak için **Ses Modelini İndir** menüsünden bir ses yükleyin."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перейдіть до **Налаштування → Доступність → VoiceOver → Мова**."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Встановіть голос за допомогою **Завантажити голосову модель**, щоб почати користуватися застосунком."
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**ترتیبات → ایکسیسبیلٹی → وائس اوور → اسپیچ** پر جائیں۔"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ایپ کا استعمال شروع کرنے کے لیے **ڈاؤن لوڈ وائس ماڈل** مینو سے آواز انسٹال کریں۔"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "转到 **设置 → 辅助功能 → VoiceOver → 语音**。"
-          }
-        }
-      }
-    },
-    "app_help_line_2_macos" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "افتح **أداة VoiceOver ← النطق**."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**VoiceOver Utility → Speech** খুলুন।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Öffne **VoiceOver-Dienstprogramm → Sprache**."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open **VoiceOver Utility → Speech**."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abre **Utilidad VoiceOver → Voz**."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrez **Utilitaire VoiceOver → Parole**."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**VoiceOver Utility → Speech** खोलें।"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nyissa meg a **VoiceOver segédprogram → Beszéd** menüpontot."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buka **Utilitas VoiceOver → Ucapan**."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apri **Utility VoiceOver → Voce**."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**VoiceOver ユーティリティ → 読み上げ** を開きます。"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open **VoiceOver-hulpprogramma → Spraak**."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otwórz **VoiceOver Utility → Mowa**."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Öppna **VoiceOver-verktyg → Tal**."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abra **Utilitário VoiceOver → Fala**."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**VoiceOver Yardımcı Programı → Konuşma**'yı açın."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Відкрийте **VoiceOver Utility → Мова**."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**VoiceOver Utility** → **Speech** کھولیں"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开 **VoiceOver 实用程序 → 语音**。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从 **Download Voice Model** 菜单安装语音以开始使用应用程序。"
           }
         }
       }
     },
-    "app_help_line_3_ios" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اضغط على **إضافة صوت الدوار**، وابحث عن الصوت الذي قمت بتثبيته تحت **Piper**، وقم باختياره."
+    "app_help_line_2_ios": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انتقل إلى **الإعدادات ← تسهيلات الاستخدام ← VoiceOver ← النطق**."
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Add Rotor Voice**-এ ট্যাপ করুন, **Piper**-এর অধীনে আপনার ইনস্টল করা ভয়েসটি খুঁজুন এবং এটি নির্বাচন করুন।"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**সেটিংস → অ্যাক্সেসিবিলিটি → ভয়েসওভার → স্পিচ**-এ যান।"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tippe auf **Rotor-Stimme hinzufügen**, suche die installierte Stimme unter **Piper** und wähle sie aus."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gehe zu **Einstellungen → Bedienungshilfen → VoiceOver → Sprache**."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tap **Add Rotor Voice**, find the voice you installed under **Piper**, and select it."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Go to **Settings → Accessibility → VoiceOver → Speech**."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toca **Añadir voz al rotor**, busca la voz que instalaste en **Piper** y selecciónala."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ve a **Ajustes → Accesibilidad → VoiceOver → Voz**."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Appuyez sur **Ajouter une voix au rotor**, trouvez la voix installée sous **Piper** et sélectionnez-la."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allez dans **Réglages → Accessibilité → VoiceOver → Parole**."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Add Rotor Voice** पर टैप करें, **Piper** के तहत आपके द्वारा इंस्टॉल की गई आवाज़ ढूंढें और उसे चुनें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**सेटिंग्स → एक्सेसिबिलिटी → वॉयसओवर → स्पीच** पर जाएं।"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Koppintson a **Rotorhang hozzáadása** elemre, keresse meg a telepített hangot a **Piper** alatt, és válassza ki."
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lépjen a **Beállítások → Kisegítő lehetőségek → VoiceOver → Beszéd** menüpontba."
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ketuk **Tambah Suara Rotor**, temukan suara yang Anda instal di bawah **Piper**, lalu pilih."
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buka **Pengaturan → Aksesibilitas → VoiceOver → Ucapan**."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tocca **Aggiungi voce rotore**, trova la voce installata sotto **Piper** e selezionala."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vai su **Impostazioni → Accessibilità → VoiceOver → Voce**."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**ローターの音声を追加** をタップし、**Piper** の下にあるインストールした音声を見つけて選択します。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**設定 → アクセシビリティ → VoiceOver → 読み上げ** に移動します。"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tik op **Voeg rotor-stem toe**, zoek de stem die je hebt geïnstalleerd onder **Piper** en selecteer deze."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ga naar **Instellingen → Toegankelijkheid → VoiceOver → Spraak**."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stuknij **Dodaj głos rotora**, znajdź głos zainstalowany w **Piper** i wybierz go."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przejdź do **Ustawienia → Dostępność → VoiceOver → Mowa**."
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tryck på **Lägg till rotor-röst**, leta reda på rösten du installerade under **Piper** och välj den."
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gå till **Inställningar → Hjälpmedel → VoiceOver → Tal**."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toque em **Adicionar Voz do Rotor**, encontre a voz instalada sob **Piper** e selecione-a."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vá em **Ajustes → Acessibilidade → VoiceOver → Fala**."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Rotor Sesini Ekle**'ye dokunun, yüklediğiniz sesi **Piper** altında bulun ve seçin."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Ayarlar → Erişilebilirlik → VoiceOver → Konuşma** bölümüne gidin."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Натисніть **Додати голос ротора**, знайдіть встановлений голос у розділі **Piper** та виберіть його."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейдіть до **Налаштування → Доступність → VoiceOver → Мова**."
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Add Rotor Voice** پر ٹیپ کریں، **Piper** کے نیچے اپنی انسٹال کردہ آواز تلاش کریں، اور اسے منتخب کریں۔"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**ترتیبات → ایکسیسبیلٹی → وائس اوور → اسپیچ** پر جائیں۔"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "点击 **添加 Rotor Voice**，找到您在 **Piper** 下安装的语音，并选择它。"
-          }
-        }
-      }
-    },
-    "app_help_line_3_macos" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "انقر على **إضافة**، ثم اختر الصوت المثبت."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Add** এ ক্লিক করুন, তারপর ইনস্টল করা ভয়েসটি নির্বাচন করুন।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Klicke auf **Hinzufügen** und wähle die installierte Stimme aus."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Click **Add**, then select the installed voice."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haz clic en **Añadir** y selecciona la voz instalada."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cliquez sur **Ajouter**, puis sélectionnez la voix installée."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**जोड़ें** पर क्लिक करें, फिर इंस्टॉल की गई आवाज़ चुनें।"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kattintson a **Hozzáadás** gombra, majd válassza ki a telepített hangot."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Klik **Tambah**, lalu pilih suara yang terinstal."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fai clic su **Aggiungi**, quindi seleziona la voce installata."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**追加** をクリックし、インストールされた音声を選択します。"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Klik op **Voeg toe** en selecteer vervolgens de geïnstalleerde stem."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kliknij **Dodaj**, a następnie wybierz zainstalowany głos."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Klicka på **Lägg till** och välj sedan den installerade rösten."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clique em **Adicionar** e selecione a voz instalada."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Ekle**'ye tıklayın, ardından yüklü sesi seçin."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Клацніть **Додати**, потім виберіть встановлений голос."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Add** پر کلک کریں، پھر انسٹال شدہ آواز کو منتخب کریں۔"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "点击 **添加**，然后选择已安装的语音。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转到 **设置 → 辅助功能 → VoiceOver → 语音**。"
           }
         }
       }
     },
-    "app_help_line_4" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "استخدم **البحث** إذا لم يظهر الصوت في القائمة."
+    "app_help_line_2_macos": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "افتح **أداة VoiceOver ← النطق**."
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ভয়েসটি তালিকায় না থাকলে **Search** ব্যবহার করুন।"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**VoiceOver Utility → Speech** খুলুন।"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nutze die **Suche**, falls die Stimme nicht in der Liste erscheint."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffne **VoiceOver-Dienstprogramm → Sprache**."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use **Search** if the voice does not appear in the list."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open **VoiceOver Utility → Speech**."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usa **Buscar** si la voz no aparece en la lista."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre **Utilidad VoiceOver → Voz**."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilisez la **Recherche** si la voix n'apparaît pas dans la liste."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrez **Utilitaire VoiceOver → Parole**."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "यदि आवाज़ सूची में दिखाई नहीं देती है तो **खोज** का उपयोग करें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**VoiceOver Utility → Speech** खोलें।"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Használja a **Keresés** funkciót, ha a hang nem jelenik meg a listában."
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nyissa meg a **VoiceOver segédprogram → Beszéd** menüpontot."
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gunakan **Cari** jika suara tidak muncul dalam daftar."
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buka **Utilitas VoiceOver → Ucapan**."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usa la **Ricerca** se la voce non appare nell'elenco."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri **Utility VoiceOver → Voce**."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "リストに音声が表示されない場合は、**検索** を使用してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**VoiceOver ユーティリティ → 読み上げ** を開きます。"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gebruik **Zoek** als de stem niet in de lijst verschijnt."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open **VoiceOver-hulpprogramma → Spraak**."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Użyj **Szukaj**, jeśli głos nie pojawia się na liście."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz **VoiceOver Utility → Mowa**."
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Använd **Sök** om rösten inte visas i listan."
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öppna **VoiceOver-verktyg → Tal**."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use a **Busca** se a voz não aparecer na lista."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abra **Utilitário VoiceOver → Fala**."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ses listede görünmüyorsa **Ara**'yı kullanın."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**VoiceOver Yardımcı Programı → Konuşma**'yı açın."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Використайте **Пошук**, якщо голос не відображається у списку."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрийте **VoiceOver Utility → Мова**."
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اگر آواز فہرست میں ظاہر نہ ہو تو **Search** کا استعمال کریں۔"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**VoiceOver Utility** → **Speech** کھولیں"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "如果语音没有出现在列表中，请使用 **搜索**。"
-          }
-        }
-      }
-    },
-    "app_help_line_5" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يمكن تثبيت أصوات مخصصة باستخدام **استيراد نموذج من الملفات** عن طريق اختيار نموذج `.onnx` وتكوين `.json` الخاص به."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "একটি `.onnx` মডেল এবং এর `.json` কনফিগারেশন নির্বাচন করে **Import Model from Files** ব্যবহার করে কাস্টম ভয়েস ইনস্টল করা যেতে পারে।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eigene Stimmen können über **Modell aus Dateien importieren** installiert werden, indem ein `.onnx`-Modell und die zugehörige `.json`-Konfiguration ausgewählt werden."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Custom voices can be installed using **Import Model from Files** by selecting a `.onnx` model and its `.json` configuration."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se pueden instalar voces personalizadas usando **Importar modelo desde archivos** seleccionando un modelo `.onnx` y su configuración `.json`."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Des voix personnalisées peuvent être installées via **Importer le modèle depuis les fichiers** en sélectionnant un modèle `.onnx` et sa configuration `.json`."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कस्टम आवाज़ें **फ़ाइलों से मॉडल आयात करें** का उपयोग करके एक `.onnx` मॉडल और उसके `.json` कॉन्फ़िगरेशन का चयन करके इंस्टॉल की जा सकती हैं।"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Egyéni hangok telepíthetők a **Modell importálása fájlokból** opcióval, egy `.onnx` modell és a hozzá tartozó `.json` konfiguráció kiválasztásával."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suara kustom dapat diinstal menggunakan **Impor Model dari Berkas** dengan memilih model `.onnx` dan konfigurasi `.json`-nya."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le voci personalizzate possono essere installate utilizzando **Importa modello da file** selezionando un modello `.onnx` e la sua configurazione `.json`."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "カスタム音声は、`.onnx` モデルとその `.json` 設定を選択して、**ファイルからモデルをインポート** を使用してインストールできます。"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aangepaste stemmen kunnen worden geïnstalleerd met **Importeer model uit bestanden** door een `.onnx`-model en de bijbehorende `.json`-configuratie te selecteren."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Własne głosy można zainstalować za pomocą **Importuj model z plików**, wybierając model `.onnx` i jego konfigurację `.json`."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anpassade röster kan installeras via **Importera modell från filer** genom att välja en `.onnx`-modell och dess `.json`-konfiguration."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vozes personalizadas podem ser instaladas usando **Importar Modelo de Arquivos** selecionando um modelo `.onnx` e sua configuração `.json`."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Özel sesler, bir `.onnx` modeli ve `.json` yapılandırmasını seçerek **Dosyalardan Model İçe Aktar** ile yüklenebilir."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Користувальницькі голоси можуть бути встановлені за допомогою **Імпортувати з файлів**, обравши модель `.onnx` і її конфігурацію `.json`."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Import Model from Files** کا استعمال کرتے ہوئے ایک **.onnx** ماڈل اور اس کی **.json** کنفیگریشن کو منتخب کر کے کسٹم آوازیں انسٹال کی جا سکتی ہیں۔"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通过选择`.onnx`模型及其`.json`配置，可以使用 **从文件中导入模型** 安装自定义语音。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开 **VoiceOver 实用程序 → 语音**。"
           }
         }
       }
     },
-    "app_help_title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مساعدة"
+    "app_help_line_3_ios": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اضغط على **إضافة صوت الدوار**، وابحث عن الصوت الذي قمت بتثبيته تحت **Piper**، وقم باختياره."
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "সাহায্য"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Add Rotor Voice**-এ ট্যাপ করুন, **Piper**-এর অধীনে আপনার ইনস্টল করা ভয়েসটি খুঁজুন এবং এটি নির্বাচন করুন।"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hilfe"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tippe auf **Rotor-Stimme hinzufügen**, suche die installierte Stimme unter **Piper** und wähle sie aus."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Help"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap **Add Rotor Voice**, find the voice you installed under **Piper**, and select it."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ayuda"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toca **Añadir voz al rotor**, busca la voz que instalaste en **Piper** y selecciónala."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aide"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appuyez sur **Ajouter une voix au rotor**, trouvez la voix installée sous **Piper** et sélectionnez-la."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सहायता"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Add Rotor Voice** पर टैप करें, **Piper** के तहत आपके द्वारा इंस्टॉल की गई आवाज़ ढूंढें और उसे चुनें।"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Súgó"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koppintson a **Rotorhang hozzáadása** elemre, keresse meg a telepített hangot a **Piper** alatt, és válassza ki."
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bantuan"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ketuk **Tambah Suara Rotor**, temukan suara yang Anda instal di bawah **Piper**, lalu pilih."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aiuto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tocca **Aggiungi voce rotore**, trova la voce installata sotto **Piper** e selezionala."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルプ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**ローターの音声を追加** をタップし、**Piper** の下にあるインストールした音声を見つけて選択します。"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hulp"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tik op **Voeg rotor-stem toe**, zoek de stem die je hebt geïnstalleerd onder **Piper** en selecteer deze."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pomoc"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stuknij **Dodaj głos rotora**, znajdź głos zainstalowany w **Piper** i wybierz go."
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hjälp"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tryck på **Lägg till rotor-röst**, leta reda på rösten du installerade under **Piper** och välj den."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajuda"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque em **Adicionar Voz do Rotor**, encontre a voz instalada sob **Piper** e selecione-a."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yardım"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Rotor Sesini Ekle**'ye dokunun, yüklediğiniz sesi **Piper** altında bulun ve seçin."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Довідка"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Натисніть **Додати голос ротора**, знайдіть встановлений голос у розділі **Piper** та виберіть його."
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Help"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Add Rotor Voice** پر ٹیپ کریں، **Piper** کے نیچے اپنی انسٹال کردہ آواز تلاش کریں، اور اسے منتخب کریں۔"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "帮助"
-          }
-        }
-      }
-    },
-    "app_version" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إصدار التطبيق"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "অ্যাপ সংস্করণ"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App-Version"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App Version"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión de la aplicación"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version de l'application"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ऐप वर्शन"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alkalmazás verziója"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versi Aplikasi"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versione app"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリのバージョン"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App-versie"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wersja aplikacji"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Appversion"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versão do App"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uygulama Sürümü"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Версія програми"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ایپ کا ورژن"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "应用版本"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击 **添加 Rotor Voice**，找到您在 **Piper** 下安装的语音，并选择它。"
           }
         }
       }
     },
-    "app_voice_info" : {
-      "comment" : "A section header for displaying information about the app's voice capabilities.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "معلومات الصوت"
+    "app_help_line_3_macos": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انقر على **إضافة**، ثم اختر الصوت المثبت."
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ভয়েস তথ্য"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Add** এ ক্লিক করুন, তারপর ইনস্টল করা ভয়েসটি নির্বাচন করুন।"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stimmen-Informationen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klicke auf **Hinzufügen** und wähle die installierte Stimme aus."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voice Information"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Click **Add**, then select the installed voice."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Información de la voz"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haz clic en **Añadir** y selecciona la voz instalada."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informations vocales"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cliquez sur **Ajouter**, puis sélectionnez la voix installée."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "आवाज़ की जानकारी"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**जोड़ें** पर क्लिक करें, फिर इंस्टॉल की गई आवाज़ चुनें।"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hanginformációk"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kattintson a **Hozzáadás** gombra, majd válassza ki a telepített hangot."
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informasi Suara"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klik **Tambah**, lalu pilih suara yang terinstal."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informazioni sulla voce"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fai clic su **Aggiungi**, quindi seleziona la voce installata."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音声情報"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**追加** をクリックし、インストールされた音声を選択します。"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stem-informatie"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klik op **Voeg toe** en selecteer vervolgens de geïnstalleerde stem."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informacje o głosach"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kliknij **Dodaj**, a następnie wybierz zainstalowany głos."
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Röstinformation"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klicka på **Lägg till** och välj sedan den installerade rösten."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informação da Voz"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clique em **Adicionar** e selecione a voz instalada."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ses Bilgisi"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Ekle**'ye tıklayın, ardından yüklü sesi seçin."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Інформація про голос"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Клацніть **Додати**, потім виберіть встановлений голос."
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "آواز کی معلومات"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Add** پر کلک کریں، پھر انسٹال شدہ آواز کو منتخب کریں۔"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "语音信息"
-          }
-        }
-      }
-    },
-    "audio_unit_status" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "حالة وحدة الصوت"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "অডিও ইউনিটের অবস্থা"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio-Unit-Status"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio Unit Status"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estado de Audio Unit"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "État de l'Audio Unit"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ऑडियो यूनिट स्थिति"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio Unit állapota"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status Unit Audio"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stato Audio Unit"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio Unit ステータス"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio Unit-status"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status jednostki audio"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio Unit-status"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status da Unidade de Áudio"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ses Birimi Durumu"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Статус Audio Unit"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "آڈیو یونٹ کی حیثیت"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音频设备状态"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击 **添加**，然后选择已安装的语音。"
           }
         }
       }
     },
-    "audio_unit_status_connected" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "متصل"
+    "app_help_line_4": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استخدم **البحث** إذا لم يظهر الصوت في القائمة."
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "সংযুক্ত"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ভয়েসটি তালিকায় না থাকলে **Search** ব্যবহার করুন।"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbunden"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nutze die **Suche**, falls die Stimme nicht in der Liste erscheint."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connected"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use **Search** if the voice does not appear in the list."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa **Buscar** si la voz no aparece en la lista."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecté"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisez la **Recherche** si la voix n'apparaît pas dans la liste."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "जुड़ा हुआ"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "यदि आवाज़ सूची में दिखाई नहीं देती है तो **खोज** का उपयोग करें।"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Csatlakozva"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Használja a **Keresés** funkciót, ha a hang nem jelenik meg a listában."
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terhubung"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gunakan **Cari** jika suara tidak muncul dalam daftar."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connesso"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa la **Ricerca** se la voce non appare nell'elenco."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "接続済み"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リストに音声が表示されない場合は、**検索** を使用してください。"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbonden"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gebruik **Zoek** als de stem niet in de lijst verschijnt."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Połączono"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Użyj **Szukaj**, jeśli głos nie pojawia się na liście."
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ansluten"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Använd **Sök** om rösten inte visas i listan."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectado"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use a **Busca** se a voz não aparecer na lista."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bağlı"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ses listede görünmüyorsa **Ara**'yı kullanın."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Підключено"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Використайте **Пошук**, якщо голос не відображається у списку."
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "جڑا ہوا"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اگر آواز فہرست میں ظاہر نہ ہو تو **Search** کا استعمال کریں۔"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已连接"
-          }
-        }
-      }
-    },
-    "audio_unit_status_disconnected" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "غير متصل"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "সংযোগ বিচ্ছিন্ন"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Getrennt"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disconnected"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desconectado"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Déconnecté"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "डिस्कनेक्ट किया गया"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Szétválasztva"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terputus"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disconnesso"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "切断済み"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Niet verbonden"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rozłączono"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frånkopplad"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desconectado"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bağlantı Kesildi"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Відключено"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "منقطع"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "断开连接"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如果语音没有出现在列表中，请使用 **搜索**。"
           }
         }
       }
     },
-    "audio_unit_status_failed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فشل الاتصال"
+    "app_help_line_5": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يمكن تثبيت أصوات مخصصة باستخدام **استيراد نموذج من الملفات** عن طريق اختيار نموذج `.onnx` وتكوين `.json` الخاص به."
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "সংযোগ করতে ব্যর্থ হয়েছে"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "একটি `.onnx` মডেল এবং এর `.json` কনফিগারেশন নির্বাচন করে **Import Model from Files** ব্যবহার করে কাস্টম ভয়েস ইনস্টল করা যেতে পারে।"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbindung fehlgeschlagen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eigene Stimmen können über **Modell aus Dateien importieren** installiert werden, indem ein `.onnx`-Modell und die zugehörige `.json`-Konfiguration ausgewählt werden."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to Connect"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom voices can be installed using **Import Model from Files** by selecting a `.onnx` model and its `.json` configuration."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error al conectar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se pueden instalar voces personalizadas usando **Importar modelo desde archivos** seleccionando un modelo `.onnx` y su configuración `.json`."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec de la connexion"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Des voix personnalisées peuvent être installées via **Importer le modèle depuis les fichiers** en sélectionnant un modèle `.onnx` et sa configuration `.json`."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कनेक्ट करने में विफल"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कस्टम आवाज़ें **फ़ाइलों से मॉडल आयात करें** का उपयोग करके एक `.onnx` मॉडल और उसके `.json` कॉन्फ़िगरेशन का चयन करके इंस्टॉल की जा सकती हैं।"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sikertelen csatlakozás"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Egyéni hangok telepíthetők a **Modell importálása fájlokból** opcióval, egy `.onnx` modell és a hozzá tartozó `.json` konfiguráció kiválasztásával."
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gagal Menghubungkan"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suara kustom dapat diinstal menggunakan **Impor Model dari Berkas** dengan memilih model `.onnx` dan konfigurasi `.json`-nya."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connessione non riuscita"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le voci personalizzate possono essere installate utilizzando **Importa modello da file** selezionando un modello `.onnx` e la sua configurazione `.json`."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "接続に失敗しました"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カスタム音声は、`.onnx` モデルとその `.json` 設定を選択して、**ファイルからモデルをインポート** を使用してインストールできます。"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbinding mislukt"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aangepaste stemmen kunnen worden geïnstalleerd met **Importeer model uit bestanden** door een `.onnx`-model en de bijbehorende `.json`-configuratie te selecteren."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie udało się połączyć"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Własne głosy można zainstalować za pomocą **Importuj model z plików**, wybierając model `.onnx` i jego konfigurację `.json`."
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anslutning misslyckades"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anpassade röster kan installeras via **Importera modell från filer** genom att välja en `.onnx`-modell och dess `.json`-konfiguration."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha ao Conectar"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vozes personalizadas podem ser instaladas usando **Importar Modelo de Arquivos** selecionando um modelo `.onnx` e sua configuração `.json`."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bağlantı Başarısız"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Özel sesler, bir `.onnx` modeli ve `.json` yapılandırmasını seçerek **Dosyalardan Model İçe Aktar** ile yüklenebilir."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не вдалося підключитися"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Користувальницькі голоси можуть бути встановлені за допомогою **Імпортувати з файлів**, обравши модель `.onnx` і її конфігурацію `.json`."
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مربوط ہونے میں ناکام"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Import Model from Files** کا استعمال کرتے ہوئے ایک **.onnx** ماڈل اور اس کی **.json** کنفیگریشن کو منتخب کر کے کسٹم آوازیں انسٹال کی جا سکتی ہیں۔"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "连接失败"
-          }
-        }
-      }
-    },
-    "cancel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إلغاء"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "বাতিল"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "रद्द करें"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mégse"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Batal"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annulla"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キャンセル"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuleer"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anuluj"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avbryt"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İptal"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скасувати"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "منسوخ کریں۔"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通过选择`.onnx`模型及其`.json`配置，可以使用 **从文件中导入模型** 安装自定义语音。"
           }
         }
       }
     },
-    "connect" : {
-      "comment" : "A button label that says \"Connect\".",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اتصال"
+    "app_help_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مساعدة"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "সংযোগ করুন"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "সাহায্য"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbinden"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hilfe"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connect"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Help"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayuda"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aide"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कनेक्ट करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सहायता"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Csatlakozás"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Súgó"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hubungkan"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bantuan"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connetti"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aiuto"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "接続"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルプ"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbind"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hulp"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Połącz"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pomoc"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anslut"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hjälp"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectar"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajuda"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bağlan"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardım"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Підключитися"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Довідка"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "جڑیں"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Help"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "连接"
-          }
-        }
-      }
-    },
-    "country" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "البلد"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "দেশ"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Land"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Country"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "País"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pays"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "देश"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ország"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Negara"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paese"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "国"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Land"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kraj"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Land"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "País"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ülke"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Країна"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ملک"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "国家"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "帮助"
           }
         }
       }
     },
-    "credits_and_legal" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الاعتمادات والقانونية"
+    "app_version": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إصدار التطبيق"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ক্রেডিট এবং আইনি"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "অ্যাপ সংস্করণ"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Danksagungen & Rechtliches"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App-Version"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Credits & Legal"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Version"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créditos y aspectos legales"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión de la aplicación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crédits et mentions légales"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version de l'application"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "क्रेडिट और कानूनी"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ऐप वर्शन"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Köszönetnyilvánítás és jogi nyilatkozat"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alkalmazás verziója"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kredit & Legal"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versi Aplikasi"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crediti e note legali"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versione app"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "クレジットと法律"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリのバージョン"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Credits & juridisch"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App-versie"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autorzy i Licencje"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wersja aplikacji"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tack & Juridisk information"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appversion"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créditos e Jurídico"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versão do App"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Katkılar & Yasal"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uygulama Sürümü"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Автори та Ліцензії"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Версія програми"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "کریڈٹ اور لائسنس"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ایپ کا ورژن"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "学分与法律"
-          }
-        }
-      }
-    },
-    "download_voice" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تحميل الصوت"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ভয়েস ডাউনলোড করুন"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stimme herunterladen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download Voice"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descargar voz"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Télécharger la voix"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "आवाज़ डाउनलोड करें"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hang letöltése"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unduh Suara"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scarica voce"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音声をダウンロード"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download stem"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pobierz głos"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ladda ner röst"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baixar Voz"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sesi İndir"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Завантажити голос"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "آواز ڈاؤن لوڈ کریں۔"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下载声音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用版本"
           }
         }
       }
     },
-    "download_voice_model" : {
-      "comment" : "A button label that downloads a voice model.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تحميل نموذج الصوت"
+    "app_voice_info": {
+      "comment": "A section header for displaying information about the app's voice capabilities.",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معلومات الصوت"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ভয়েস মডেল ডাউনলোড করুন"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ভয়েস তথ্য"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprachmodell herunterladen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stimmen-Informationen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download Voice Model"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice Information"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descargar modelo de voz"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Información de la voz"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Télécharger le modèle de voix"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informations vocales"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "वॉयस मॉडल डाउनलोड करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आवाज़ की जानकारी"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hangmodell letöltése"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hanginformációk"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unduh Model Suara"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informasi Suara"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scarica modello vocale"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informazioni sulla voce"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音声モデルをダウンロード"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声情報"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download spraakmodel"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stem-informatie"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pobierz model głosu"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informacje o głosach"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ladda ner röstmodell"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Röstinformation"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baixar Modelo de Voz"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informação da Voz"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ses Modelini İndir"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ses Bilgisi"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Завантажити голосову модель"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Інформація про голос"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "وائس ماڈل ڈاؤن لوڈ کریں۔"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آواز کی معلومات"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下载语音模型"
-          }
-        }
-      }
-    },
-    "downloaded" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تم التحميل"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ডাউনলোড করা হয়েছে"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Heruntergeladen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Downloaded"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descargado"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Téléchargé"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "डाउनलोड किया गया"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Letöltve"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terunduh"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scaricato"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダウンロード済み"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gedownload"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pobrano"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nedladdad"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baixado"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İndirildi"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Завантажено"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ڈاؤن لوڈ کیا گیا۔"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已下载"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语音信息"
           }
         }
       }
     },
-    "downloading" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "جاري التحميل"
+    "audio_unit_status": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حالة وحدة الصوت"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ডাউনলোড হচ্ছে"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "অডিও ইউনিটের অবস্থা"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird heruntergeladen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio-Unit-Status"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Downloading"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio Unit Status"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descargando"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado de Audio Unit"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Téléchargement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "État de l'Audio Unit"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "डाउनलोड हो रहा है"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ऑडियो यूनिट स्थिति"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Letöltés"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio Unit állapota"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mengunduh"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status Unit Audio"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download in corso"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stato Audio Unit"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダウンロード中"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio Unit ステータス"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Downloaden"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio Unit-status"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pobieranie"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status jednostki audio"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laddar ner"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio Unit-status"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baixando"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status da Unidade de Áudio"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İndiriliyor"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ses Birimi Durumu"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Завантажується"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Статус Audio Unit"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ڈاؤن لوڈ ہو رہا ہے۔"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آڈیو یونٹ کی حیثیت"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在下载"
-          }
-        }
-      }
-    },
-    "error" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "خطأ"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ত্রুটি"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fehler"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "त्रुटि"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hiba"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kesalahan"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Errore"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "エラー"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fout"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pomyłka"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fel"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erro"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hata"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Помилка"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "خرابی"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "错误"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音频设备状态"
           }
         }
       }
     },
-    "export_file" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تصدير الملف"
+    "audio_unit_status_connected": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "متصل"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ফাইল এক্সপোর্ট করুন"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "সংযুক্ত"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datei exportieren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbunden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Export File"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connected"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportar archivo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exporter le fichier"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecté"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "फ़ाइल एक्सपोर्ट करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जुड़ा हुआ"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fájl exportálása"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Csatlakozva"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ekspor Berkas"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terhubung"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esporta file"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connesso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ファイルを書き出す"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続済み"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exporteer bestand"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbonden"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eksportuj plik"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Połączono"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportera fil"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ansluten"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportar Arquivo"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectado"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dosyayı Dışa Aktar"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bağlı"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отримати запис"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підключено"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فائل برآمد کریں۔"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جڑا ہوا"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "导出文件"
-          }
-        }
-      }
-    },
-    "installed_voices" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الأصوات المثبتة"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ইনস্টল করা ভয়েস"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installierte Stimmen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Voices"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voces instaladas"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voix installées"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "इंस्टॉल की गई आवाज़ें"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Telepített hangok"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suara Terinstal"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voci installate"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インストール済みの音声"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geïnstalleerde stemmen"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zainstalowane głosy"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installerade röster"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vozes Instaladas"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yüklenen Sesler"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Встановлені Голоси"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "انسٹال شدہ آوازیں۔"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已安装的声音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已连接"
           }
         }
       }
     },
-    "json_error_data_corrupted_%@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "البيانات تالفة: %@"
+    "audio_unit_status_disconnected": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غير متصل"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "তথ্য দূষিত: %@"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "সংযোগ বিচ্ছিন্ন"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Daten sind beschädigt: %@"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Getrennt"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The data is corrupted: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnected"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Los datos están dañados: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconectado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les données sont corrompues : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déconnecté"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "डेटा दूषित है: %@"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डिस्कनेक्ट किया गया"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Az adatok sérültek: %@"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Szétválasztva"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Data korup: %@"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terputus"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I dati sono corrotti: %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnesso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "データが破損しています: %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切断済み"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "De gegevens zijn beschadigd: %@"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niet verbonden"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dane są uszkodzone: %@"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozłączono"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datan är korrupt: %@"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frånkopplad"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Os dados estão corrompidos: %@"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconectado"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Veriler bozulmuş: %@"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bağlantı Kesildi"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Дані пошкоджені: %@"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відключено"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ڈیٹا کرپٹ ہے: %@"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "منقطع"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "数据已损坏：%@"
-          }
-        }
-      }
-    },
-    "json_error_invalid_model_file_path" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مسار ملف النموذج غير صالح."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "অবৈধ মডেল ফাইল পাথ।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ungültiger Modell-Dateipfad."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid model file path."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ruta del archivo del modelo no válida."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chemin du fichier de modèle invalide."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "अमान्य मॉडल फ़ाइल पथ।"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Érvénytelen modellfájl elérési út."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jalur berkas model tidak valid."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Percorso del file del modello non valido."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "モデルファイルのパスが無効です。"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ongeldig bestandspad voor model."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nieprawidłowa ścieżka do pliku modelu."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ogiltig filsökväg för modell."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Caminho de arquivo de modelo inválido."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geçersiz model dosya yolu."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Недійсний шлях до файлу моделі."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "غلط ماڈل فائل پاتھ۔"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "模型文件路径无效。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "断开连接"
           }
         }
       }
     },
-    "json_error_missing_field_%@_at_%@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الحقل ‘%@’ مفقود في ‘%@’"
+    "audio_unit_status_failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فشل الاتصال"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‘%@’ ক্ষেত্রটি ‘%@’ এ অনুপস্থিত"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "সংযোগ করতে ব্যর্থ হয়েছে"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das Feld ‘%@’ fehlt bei ‘%@’"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung fehlgeschlagen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The field ‘%@’ is missing at ‘%@’"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to Connect"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falta el campo ‘%@’ en ‘%@’"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error al conectar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le champ ‘%@’ est manquant à ‘%@’"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de la connexion"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‘%@’ फ़ील्ड ‘%@’ पर गायब है"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कनेक्ट करने में विफल"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A(z) ‘%@’ mező hiányzik itt: ‘%@’"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sikertelen csatlakozás"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bidang ‘%@’ tidak ditemukan di ‘%@’"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gagal Menghubungkan"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Il campo ‘%@’ è mancante in ‘%@’"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connessione non riuscita"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‘%@’ フィールドが ‘%@’ に見つかりません"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続に失敗しました"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Het veld ‘%@’ ontbreekt bij ‘%@’"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinding mislukt"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pole „%@” nie występuje w „%@”"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie udało się połączyć"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fältet ‘%@’ saknas vid ‘%@’"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anslutning misslyckades"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O campo ‘%@’ está faltando em ‘%@’"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha ao Conectar"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‘%@’ alanı ‘%@’ konumunda eksik."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bağlantı Başarısız"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Поле «%@» відсутнє у «%@»"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося підключитися"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فیلڈ '%@' '%@' پر غائب ہے"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مربوط ہونے میں ناکام"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "字段“%@”在“%@”处缺失"
-          }
-        }
-      }
-    },
-    "json_error_type_mismatch_%@_at_%@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "توقع قيمة من نوع '%@' في '%@'، ولكن وجد شيء آخر."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "'%@' এ '%@' টাইপের মান প্রত্যাশিত ছিল, কিন্তু অন্য কিছু পাওয়া গেছে।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wert vom Typ '%@' bei '%@' erwartet, aber etwas anderes gefunden."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Expected a value of type '%@' at '%@', but found something else."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se esperaba un valor de tipo '%@' en '%@', pero se encontró otra cosa."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valeur de type '%@' attendue à '%@', mais autre chose a été trouvé."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "'%@' पर '%@' प्रकार के मान की अपेक्षा थी, लेकिन कुछ और मिला।"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "'%@' típusú értéket vártunk a(z) '%@' helyen, de mást találtunk."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mengharapkan nilai tipe '%@' di '%@', tetapi menemukan hal lain."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atteso un valore di tipo '%@' in '%@', ma è stato trovato altro."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "'%@' にタイプ '%@' の値が期待されましたが、別のものが見つかりました。"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwachtte een waarde van type '%@' bij '%@', maar vond iets anders."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oczekiwano wartości typu '%@' w '%@', ale znaleziono coś innego."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Väntade ett värde av typen '%@' vid '%@', men hittade något annat."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esperava um valor do tipo '%@' em '%@', mas encontrou outra coisa."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "'%@' konumunda '%@' türünde bir değer bekleniyordu, ancak başka bir şey bulundu."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очікувалося значення типу '%@' у '%@', але знайдено щось інше."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "'%@' پر '%@' قسم کی قدر کی توقع تھی، لیکن کچھ اور ملا۔"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "预期在“%@”处找到类型为“%@”的值，但找到的是其他类型。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接失败"
           }
         }
       }
     },
-    "json_error_value_not_found_%@_at_%@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "القيمة المطلوبة من نوع '%@' كانت فارغة في '%@'."
+    "cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إلغاء"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "'%@' এ '%@' টাইপের প্রয়োজনীয় মানটি শূন্য ছিল।"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "বাতিল"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erforderlicher Wert vom Typ '%@' war null bei '%@'."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Required value of type '%@' was null at '%@'."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El valor requerido de tipo '%@' era nulo en '%@'."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La valeur requise de type '%@' était nulle à '%@'."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "'%@' प्रकार का आवश्यक मान '%@' पर शून्य (null) था।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रद्द करें"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A(z) '%@' típusú kötelező érték null volt itt: '%@'."
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mégse"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nilai yang diperlukan dari tipe '%@' adalah null di '%@'."
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Batal"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Il valore richiesto di tipo '%@' era nullo in '%@'."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "'%@' に必要なタイプ '%@' の値が NULL でした。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vereiste waarde van type '%@' was null bij '%@'."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuleer"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wymagana wartość typu '%@' była równa null dla '%@'."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anuluj"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nödvändigt värde av typen '%@' saknades vid '%@'."
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avbryt"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O valor obrigatório do tipo '%@' era nulo em '%@'."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "'%@' türündeki gerekli değer '%@' konumunda boştu."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İptal"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Необхідне значення типу '%@' було null у '%@'."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скасувати"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "قسم '%@' کی مطلوبہ قدر '%@' پر کالعدم تھی۔"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "منسوخ کریں۔"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "类型为“%@”的必需值为空。"
-          }
-        }
-      }
-    },
-    "language" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اللغة"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ভাষা"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprache"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Language"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Idioma"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Langue"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "भाषा"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nyelv"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lingua"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "言語"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Taal"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bahasa"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Język"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Språk"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Idioma"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dil"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Мова"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "زبان"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "语言"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         }
       }
     },
-    "languages" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اللغات"
+    "connect": {
+      "comment": "A button label that says \"Connect\".",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اتصال"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ভাষাগুলো"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "সংযোগ করুন"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprachen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Languages"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Idiomas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Langues"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecter"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "भाषाएँ"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कनेक्ट करें"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nyelvek"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Csatlakozás"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lingue"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hubungkan"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "言語"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connetti"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Talen"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bahasa"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbind"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Języki"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Połącz"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Språk"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anslut"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Idiomas"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diller"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bağlan"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Мови"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підключитися"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "زبانیں"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جڑیں"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "语言"
-          }
-        }
-      }
-    },
-    "license_audio_unit_description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ملحق وحدة الصوت هذا، الذي يتضمن eSpeak-NG و Piper1-GPL، مرخص تحت GPLv3."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "এই অডিও ইউনিট এক্সটেন্সন, যার মধ্যে eSpeak-NG এবং Piper1-GPL অন্তর্ভুক্ত রয়েছে, GPLv3 এর অধীনে লাইসেন্সপ্রাপ্ত।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diese Audio-Unit-Erweiterung, die eSpeak-NG und Piper1-GPL enthält, ist unter der GPLv3 lizenziert."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This Audio Unit Extension, which includes eSpeak-NG and Piper1-GPL, is licensed under GPLv3."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta extensión de Audio Unit, que incluye eSpeak-NG y Piper1-GPL, tiene licencia GPLv3."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cette extension Audio Unit, qui inclut eSpeak-NG et Piper1-GPL, est sous licence GPLv3."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "यह ऑडियो यूनिट एक्सटेंशन, जिसमें eSpeak-NG और Piper1-GPL शामिल हैं, GPLv3 के तहत लाइसेंस प्राप्त है।"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ez az Audio Unit bővítmény, amely tartalmazza az eSpeak-NG-t és a Piper1-GPL-t, a GPLv3 licenc alatt áll."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ekstensi Unit Audio ini, yang mencakup eSpeak-NG dan Piper1-GPL, dilisensikan di bawah GPLv3."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Questa estensione Audio Unit, che include eSpeak-NG e Piper1-GPL, è concessa in licenza sotto GPLv3."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak-NG と Piper1-GPL を含むこの Audio Unit 拡張機能は、GPLv3 に基づいてライセンスされています。"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deze Audio Unit-extensie, inclusief eSpeak-NG en Piper1-GPL, is gelicentieerd onder GPLv3."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To rozszerzenie Audio Unit, które zawiera eSpeak-NG i Piper1-GPL, jest licencjonowane na GPLv3."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detta Audio Unit-tillägg, som inkluderar eSpeak-NG och Piper1-GPL, är licensierat under GPLv3."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta Extensão de Unidade de Áudio, que inclui eSpeak-NG e Piper1-GPL, é licenciada sob a GPLv3."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak-NG ve Piper1-GPL içeren bu Ses Birimi Eklentisi GPLv3 lisanslıdır."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Цей Audio Unit Extension, що включає eSpeak-NG та Piper1-GPL, ліцензований за GPLv3."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "یہ آڈیو یونٹ ایکسٹینشن، جس میں eSpeak-NG اور Piper1-GPL شامل ہیں، GPLv3 کے تحت  لائسنس یافتہ ہے۔"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此音频单元扩展包括eSpeak-NG和 Piper1-GPL，它是GPLv3授权的。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接"
           }
         }
       }
     },
-    "license_audio_unit_title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ملحق وحدة الصوت (GPLv3)"
+    "country": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "البلد"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "অডিও ইউনিট এক্সটেনশন (GPLv3)"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "দেশ"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio-Unit-Erweiterung (GPLv3)"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Land"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio Unit Extension (GPLv3)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Country"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Extensión de Audio Unit (GPLv3)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "País"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Extension Audio Unit (GPLv3)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pays"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ऑडियो यूनिट एक्सटेंशन (GPLv3)"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "देश"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio Unit bővítmény (GPLv3)"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ország"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ekstensi Unit Audio (GPLv3)"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Negara"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estensione Audio Unit (GPLv3)"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paese"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio Unit 拡張機能 (GPLv3)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "国"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio Unit-extensie (GPLv3)"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Land"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rozszerzenie Audio Unit (GPLv3)"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kraj"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio Unit-tillägg (GPLv3)"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Land"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Extensão de Unidade de Áudio (GPLv3)"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "País"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ses Birimi Eklentisi (GPLv3)"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ülke"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio Unit Extension (GPLv3)"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Країна"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "آڈیو یونٹ ایکسٹینشن (GPLv3)"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ملک"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音频单元扩展 (GPLv3)"
-          }
-        }
-      }
-    },
-    "license_espeak_ng_description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak NG هو محرك نطق خفيف الوزن ومفتوح المصدر يدعم أكثر من 100 لغة ولهجة."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak NG একটি হালকা ওপেন-সোর্স টেক্সট-টু-স্পিচ ইঞ্জিন যা ১০০টিরও বেশি ভাষা এবং অ্যাকসেন্ট সমর্থন করে।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak NG ist eine leichtgewichtige Open-Source-Text-to-Speech-Engine, die über 100 Sprachen und Akzente unterstützt."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak NG is a lightweight open-source text-to-speech engine supporting over 100 languages and accents."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak NG es un motor de texto a voz de código abierto y ligero que admite más de 100 idiomas y acentos."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak NG est un moteur de synthèse vocale open source léger prenant en charge plus de 100 langues et accents."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak NG एक हल्का ओपन-सोर्स टेक्स्ट-टू-स्पीच इंजन है जो 100 से अधिक भाषाओं और लहजों का समर्थन करता है।"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Az eSpeak NG egy könnyű, nyílt forráskódú szövegfelolvasó motor, amely több mint 100 nyelvet és akcentust támogat."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak NG adalah mesin text-to-speech sumber terbuka ringan yang mendukung lebih dari 100 bahasa dan aksen."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak NG è un motore di sintesi vocale open source leggero che supporta oltre 100 lingue e accenti."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak NG は、100 以上の言語とアクセントをサポートする軽量のオープンソース テキスト読み上げエンジンです。"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak NG is een lichtgewicht open-source tekst-naar-spraak-engine die meer dan 100 talen en accenten ondersteunt."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak NG to lekki, otwartoźródłowy silnik TTS obsługujący ponad 100 języków i akcentów."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak NG är en lättviktig text-till-tal-motor med öppen källkod som stöder över 100 språk och dialekter."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "o eSpeak NG é um mecanismo de conversão de texto em fala de código aberto leve que suporta mais de 100 idiomas e sotaques."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak NG, 100’den fazla dili ve aksanı destekleyen hafif açık kaynaklı bir metinden konuşmaya motorudur."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak NG - це швидкий механізм перетворення тексту в мовлення з відкритим кодом, який підтримує понад 100 мов та акцентів."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak NG ایک ہلکا پھلکا اوپن سورس ٹیکسٹ ٹو اسپیچ انجن ہے جو 100 سے زیادہ زبانوں اور لہجوں کو سپورٹ کرتا ہے۔"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eSpeak NG 是一个轻量开源文字转语音引擎，支持100多种语言和音量。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "国家"
           }
         }
       }
     },
-    "license_main_app_%@_title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تطبيق Piper %@ (MIT)"
+    "credits_and_legal": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الاعتمادات والقانونية"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper %@ অ্যাপ (MIT)"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ক্রেডিট এবং আইনি"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper %@ App (MIT)"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Danksagungen & Rechtliches"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper %@ App (MIT)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credits & Legal"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aplicación Piper %@ (MIT)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créditos y aspectos legales"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Application Piper %@ (MIT)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crédits et mentions légales"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "पाइपर %@ ऐप (MIT)"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "क्रेडिट और कानूनी"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper %@ alkalmazás (MIT)"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Köszönetnyilvánítás és jogi nyilatkozat"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aplikasi Piper %@ (MIT)"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kredit & Legal"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App Piper %@ (MIT)"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crediti e note legali"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper %@ アプリ (MIT)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クレジットと法律"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper %@ App (MIT)"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credits & juridisch"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper %@ Aplikacja (MIT)"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autorzy i Licencje"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper %@ App (MIT)"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tack & Juridisk information"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App Piper %@ (MIT)"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créditos e Jurídico"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper %@ Uygulaması (MIT)"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Katkılar & Yasal"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper %@ Додаток (MIT)"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автори та Ліцензії"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper %@ App (MIT)"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کریڈٹ اور لائسنس"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper %@ App (MIT)"
-          }
-        }
-      }
-    },
-    "license_main_app_description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تطبيق Piper، الذي طوره [Ihor Shevchuk](https://ihor-shevchuk.dev)، مرخص تحت MIT. إنه برنامج منفصل ويتواصل مع ملحق وحدة الصوت فقط عبر XPC."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "[Ihor Shevchuk](https://ihor-shevchuk.dev) দ্বারা তৈরি পাইপার অ্যাপটি MIT এর অধীনে লাইসেন্সপ্রাপ্ত। এটি একটি পৃথক প্রোগ্রাম এবং শুধুমাত্র XPC এর মাধ্যমে অডিও ইউনিট এক্সটেন্সনের সাথে যোগাযোগ করে।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Piper-App, entwickelt von Ihor Shevchuk, steht unter der MIT-Lizenz. Sie ist ein eigenständiges Programm und kommuniziert mit der Audio-Unit-Erweiterung ausschließlich über XPC."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper App, developed by [Ihor Shevchuk](https://ihor-shevchuk.dev), is licensed under MIT. It is a separate program and communicates with the Audio Unit Extension only via XPC."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La aplicación Piper, desarrollada por Ihor Shevchuk, tiene licencia MIT. Es un programa independiente y se comunica con la extensión de Audio Unit solo a través de XPC."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'application Piper, développée par Ihor Shevchuk, est sous licence MIT. Il s'agit d'un programme distinct qui communique avec l'extension Audio Unit uniquement via XPC."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "पाइपर ऐप, Ihor Shevchuk द्वारा विकसित, MIT के तहत लाइसेंस प्राप्त है। यह एक अलग प्रोग्राम है और केवल XPC के माध्यम से ऑडियो यूनिट एक्सटेंशन के साथ संचार करता है।"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A Piper alkalmazás, amelyet Ihor Shevchuk fejlesztett ki, MIT licenc alatt áll. Ez egy különálló program, amely kizárólag XPC-n keresztül kommunikál az Audio Unit bővítménnyel."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aplikasi Piper, dikembangkan oleh [Ihor Shevchuk](https://ihor-shevchuk.dev), dilisensikan di bawah MIT. Ini adalah program terpisah dan berkomunikasi dengan Ekstensi Unit Audio hanya melalui XPC."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'app Piper, sviluppata da Ihor Shevchuk, è concessa in licenza sotto MIT. È un programma separato e comunica con l'estensione Audio Unit solo tramite XPC."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ihor Shevchuk によって開発された Piper アプリは、MIT に基づいてライセンスされています。これは別のプログラムであり、XPC 経由でのみ Audio Unit 拡張機能と通信します。"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "De Piper App, ontwikkeld door Ihor Shevchuk, is gelicentieerd onder MIT. Het is een apart programma en communiceert alleen via XPC met de Audio Unit-extensie."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aplikacja Piper, stworzona przez [Ihora Szewczuka](https://ihor-shevchuk.dev), jest licencjonowana na MIT. To osobny program, który komunikuje się z rozszerzeniem Audio Unit wyłącznie przez XPC."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper App, utvecklad av Ihor Shevchuk, är licensierad under MIT. Det är ett separat program och kommunicerar endast med Audio Unit-tillägget via XPC."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O App Piper, desenvolvido por [Ihor Shevchuk](https://ihor-shevchuk.dev), é licenciado sob a MIT. É um programa separado e se comunica com a Extensão de Unidade de Áudio apenas via XPC."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "[Ihor Shevchuk](https://ihor-shevchuk.dev) tarafından geliştirilen Piper Uygulaması MIT lisanslıdır. Bu ayrı bir programdır ve Ses Birimi Eklentisi ile yalnızca XPC üzerinden iletişim kurar."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Додаток Piper, розроблений [Ігорем Шевчуком](https://ihor-shevchuk.dev), ліцензований за MIT. Це окрема програма, яка взаємодіє з Audio Unit Extension лише через XPC."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "پائپر ایپ، جسے [Ihor Shevchuk](https://ihor-shevchuk.dev) نے تیار کیا ہے، MIT کے تحت لائسنس یافتہ ہے۔ یہ ایک الگ پروگرام ہے اور صرف XPC کے ذریعے آڈیو یونٹ ایکسٹینشن کے ساتھ بات چیت کرتا ہے۔"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper App 是由 [Ihor Shevchuk](https://ihor-shevchuk.dev) 开发的，是在 MIT 下授权的。这是一个单独的程序，仅通过 XPC 与音频设备扩展进行通信。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学分与法律"
           }
         }
       }
     },
-    "license_piper_description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper هو محرك نطق عصبي سريع ومفتوح المصدر طوره مجتمع OHF-Voice."
+    "download_voice": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحميل الصوت"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper হল একটি দ্রুত, ওপেন-সোর্স নিউরাল টেক্সট-টু-স্পিচ ইঞ্জিন যা OHF-Voice সম্প্রদায় দ্বারা তৈরি করা হয়েছে।"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ভয়েস ডাউনলোড করুন"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper ist eine schnelle Open-Source-Neural-Text-to-Speech-Engine, die von der OHF-Voice-Community entwickelt wurde."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stimme herunterladen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper is a fast, open-source neural text-to-speech engine developed by the OHF-Voice community."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download Voice"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper es un motor de texto a voz neuronal rápido y de código abierto desarrollado por la comunidad OHF-Voice."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar voz"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper est un moteur de synthèse vocale neuronale rapide et open source développé par la communauté OHF-Voice."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharger la voix"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "पाइपर एक तेज़, ओपन-सोर्स न्यूरल टेक्स्ट-टू-स्पीच इंजन है जिसे OHF-Voice समुदाय द्वारा विकसित किया गया है।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आवाज़ डाउनलोड करें"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A Piper egy gyors, nyílt forráskódú neurális szövegfelolvasó motor, amelyet az OHF-Voice közösség fejlesztett ki."
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hang letöltése"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper adalah mesin text-to-speech saraf sumber terbuka yang cepat yang dikembangkan oleh komunitas OHF-Voice."
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unduh Suara"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper è un motore di sintesi vocale neurale veloce e open source sviluppato dalla comunità OHF-Voice."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scarica voce"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper は、OHF-Voice コミュニティによって開発された高速でオープンソースのニューラル テキスト読み上げエンジンです。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声をダウンロード"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper is een snelle, open-source neurale tekst-naar-spraak-engine ontwikkeld door de OHF-Voice community."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download stem"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper to szybki, otwartoźródłowy, neuronowy silnik TTS opracowany przez społeczność OHF-Voice."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pobierz głos"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper är en snabb röstmotor för text-till-tal baserad på neurala nätverk med öppen källkod, utvecklad av OHF-Voice-communityn."
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ladda ner röst"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O Piper é um mecanismo de conversão de texto em fala neural rápido e de código aberto desenvolvido pela comunidade OHF-Voice."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Baixar Voz"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper, OHF-Voice topluluğu tarafından geliştirilen hızlı, açık kaynaklı bir sinirsel metinden konuşmaya motorudur."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesi İndir"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper — це швидкий двигун синтезу мовлення, розроблений OHF-Voice community. з відкритим кодом."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завантажити голос"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "پائپر ایک تیز، اوپن سورس نیورل ٹیکسٹ ٹو اسپیچ انجن ہے جسے OHF-Voice کمیونٹی نے تیار کیا ہے۔"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آواز ڈاؤن لوڈ کریں۔"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper是一个由OHF-Voice 社区开发的快速开放源码文字转语音引擎。"
-          }
-        }
-      }
-    },
-    "model" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نموذج"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "মডেল"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Model"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelo"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modèle"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "मॉडल"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Model"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modello"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "モデル"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Model"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Model"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelo"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Model"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Модель"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اے آئی ماڈل"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "模型"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载声音"
           }
         }
       }
     },
-    "no_voices" : {
-      "comment" : "A placeholder text to display when a language has no available voices.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا توجد أصوات متاحة"
+    "download_voice_model": {
+      "comment": "A button label that downloads a voice model.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحميل نموذج الصوت"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "কোনো ভয়েস উপলব্ধ নেই"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ভয়েস মডেল ডাউনলোড করুন"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Stimmen verfügbar"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprachmodell herunterladen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No voices available"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download Voice Model"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay voces disponibles"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar modelo de voz"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune voix disponible"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharger le modèle de voix"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कोई आवाज़ उपलब्ध नहीं है"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वॉयस मॉडल डाउनलोड करें"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nem állnak rendelkezésre hangok"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hangmodell letöltése"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tidak ada suara yang tersedia"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unduh Model Suara"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessuna voce disponibile"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scarica modello vocale"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "利用可能な音声はありません"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声モデルをダウンロード"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geen stemmen beschikbaar"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download spraakmodel"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Brak dostępnych głosów"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pobierz model głosu"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inga röster tillgängliga"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ladda ner röstmodell"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhuma voz disponível"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Baixar Modelo de Voz"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kullanılabilir ses yok"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ses Modelini İndir"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Голосів немає"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завантажити голосову модель"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "کوئی آوازیں دستیاب نہیں ہیں۔"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وائس ماڈل ڈاؤن لوڈ کریں۔"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "没有可用的声音"
-          }
-        }
-      }
-    },
-    "no_voices_message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**لم يتم تثبيت أي أصوات بعد.**\nاستخدم زر **تحميل نموذج الصوت** أدناه لإضافة صوت."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**এখনো কোনো ভয়েস ইনস্টল করা হয়নি।**\nএকটি ভয়েস যোগ করতে নিচের **ভয়েস মডেল ডাউনলোড করুন** বোতামটি ব্যবহার করুন।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Es sind noch keine Stimmen installiert.**\nNutze die Schaltfläche **Sprachmodell herunterladen** unten, um eine Stimme hinzuzufügen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**No voices are installed yet.**\nUse the **Download Voice Model** button below to add a voice."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Aún no hay voces instaladas.**\nUsa el botón **Descargar modelo de voz** de abajo para añadir una voz."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Aucune voix n'est installée.**\nUtilisez le bouton **Télécharger le modèle de voix** ci-dessous pour ajouter une voix."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**अभी तक कोई आवाज़ इंस्टॉल नहीं की गई है।**\nआवाज़ जोड़ने के लिए नीचे दिए गए **वॉयस मॉडल डाउनलोड करें** बटन का उपयोग करें।"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Még nincsenek hangok telepítve.**\nHang hozzáadásához használja az alábbi **Hangmodell letöltése** gombot."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Belum ada suara yang diinstal.**\nGunakan tombol **Unduh Model Suara** di bawah ini untuk menambahkan suara."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Nessuna voce ancora installata.**\nUsa il pulsante **Scarica modello vocale** qui sotto per aggiungere una voce."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**音声がまだインストールされていません。**\n下の **音声モデルをダウンロード** ボタンを使用して音声を追加してください。"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Er zijn nog geen stemmen geïnstalleerd.**\nGebruik de knop **Download spraakmodel** hieronder om een stem toe te voegen."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Żadne głosy nie są jeszcze zainstalowane.**\nUżyj przycisku **Pobierz model głosu** poniżej, aby dodać głos."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Inga röster är installerade än.**\nAnvänd knappen **Ladda ner röstmodell** nedan för att lägga till en röst."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Nenhuma voz está instalada ainda.**\nUse o botão **Baixar Modelo de Voz** abaixo para adicionar uma voz."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Henüz hiçbir ses yüklenmedi.**\nBir ses eklemek için aşağıdaki **Ses Modelini İndir** düğmesini kullanın."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Жодного голосу ще не встановлено.**  \nЩоб додати голос, скористайтеся кнопкою **Завантажити голосову модель** нижче."
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**ابھی تک کوئی آوازیں انسٹال نہیں ہیں۔**\nآواز شامل کرنے کے لیے نیچے **وائس ماڈل ڈاؤن لوڈ کریں** بٹن کا استعمال کریں۔"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**尚未安装声音。**\n使用下面的 **下载语音模型** 按钮添加语音。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载语音模型"
           }
         }
       }
     },
-    "ok" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "موافق"
+    "downloaded": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم التحميل"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ঠিক আছে"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ডাউনলোড করা হয়েছে"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heruntergeladen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ok"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloaded"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aceptar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Téléchargé"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ठीक है"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डाउनलोड किया गया"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letöltve"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oke"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terunduh"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scaricato"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダウンロード済み"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gedownload"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pobrano"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ok"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nedladdad"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Baixado"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tamam"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İndirildi"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Гаразд"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завантажено"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ٹھیک ہے"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈاؤن لوڈ کیا گیا۔"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "好的"
-          }
-        }
-      }
-    },
-    "onnx_file" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ملف ONNX"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ONNX ফাইল"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ONNX-Datei"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ONNX File"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Archivo ONNX"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fichier ONNX"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ONNX फ़ाइल"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ONNX fájl"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Berkas ONNX"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "File ONNX"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ONNX ファイル"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ONNX-bestand"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plik ONNX"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ONNX-fil"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arquivo ONNX"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ONNX Dosyası"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Файл ONNX"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ONNX فائل"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ONNX 文件"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已下载"
           }
         }
       }
     },
-    "piper_app_name" : {
-      "comment" : "The title of the main view.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper"
+    "downloading": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جاري التحميل"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ডাউনলোড হচ্ছে"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird heruntergeladen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloading"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargando"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Téléchargement"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "पाइपर"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डाउनलोड हो रहा है"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letöltés"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mengunduh"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download in corso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダウンロード中"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloaden"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pobieranie"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laddar ner"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Baixando"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İndiriliyor"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завантажується"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈاؤن لوڈ ہو رہا ہے۔"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piper"
-          }
-        }
-      }
-    },
-    "play_sample" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تشغيل عينة"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "নমুনা প্লে করুন"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beispiel abspielen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Play Sample"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reproducir muestra"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lire l'échantillon"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "नमूना बजाएं"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Minta lejátszása"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Putar Sampel"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Riproduci campione"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サンプルを再生"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speel voorbeeld af"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odtwórz próbkę"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spela prov"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reproduzir Amostra"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Örnek Oynat"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Відтворити приклад"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نمونہ کھیلیں"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "播放示例"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在下载"
           }
         }
       }
     },
-    "quality" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الجودة"
+    "error": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خطأ"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "গুণমান"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ত্রুটি"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Qualität"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quality"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Calidad"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Qualité"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "गुणवत्ता"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "त्रुटि"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Minőség"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiba"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kualitas"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kesalahan"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Qualità"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Errore"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "品質"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エラー"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kwaliteit"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fout"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jakość"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pomyłka"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kvalitet"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fel"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Qualidade"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erro"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kalite"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hata"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Якість"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помилка"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "معیار"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خرابی"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "质量"
-          }
-        }
-      }
-    },
-    "sample_rate" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "معدل العينة"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "স্যাম্পল রেট"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abtastrate"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sample Rate"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frecuencia de muestreo"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Taux d'échantillonnage"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सैंपल रेट"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mintavételezési gyakoriság"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laju Sampel"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frequenza di campionamento"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サンプリングレート"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Samplefrequentie"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Częstotliwość próbkowania"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Samplingsfrekvens"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Taxa de Amostragem"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Örnekleme Hızı"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Частота"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نمونہ کی شرح"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "采样率"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "错误"
           }
         }
       }
     },
-    "sample_text" : {
-      "comment" : "A text field for entering sample text.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نص العينة"
+    "export_file": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصدير الملف"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "নমুনা টেক্সট"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ফাইল এক্সপোর্ট করুন"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beispieltext"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datei exportieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sample Text"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export File"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Texto de muestra"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar archivo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Texte d'exemple"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporter le fichier"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "नमूना पाठ"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "फ़ाइल एक्सपोर्ट करें"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mintaszöveg"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fájl exportálása"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Teks Sampel"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ekspor Berkas"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Testo di esempio"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esporta file"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サンプルテキスト"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルを書き出す"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voorbeeldtekst"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporteer bestand"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przykładowy tekst"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eksportuj plik"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exempeltext"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportera fil"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Texto de Amostra"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar Arquivo"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Örnek Metin"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dosyayı Dışa Aktar"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Текст прикладу"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отримати запис"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نمونہ متن"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فائل برآمد کریں۔"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "示例文本"
-          }
-        }
-      }
-    },
-    "sample_text: %@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نص العينة: %1$@"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "নমুনা টেক্সট: %1$@"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beispieltext: %1$@"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sample Text: %1$@"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Texto de muestra: %1$@"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Texte d'exemple : %1$@"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "नमूना पाठ: %1$@"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mintaszöveg: %1$@"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Teks Sampel: %1$@"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Testo di esempio: %1$@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サンプルテキスト: %1$@"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voorbeeldtekst: %1$@"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przykładowy tekst: %1$@"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exempeltext: %1$@"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Texto de Amostra: %1$@"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Örnek Metin: %1$@"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Приклад: %1$@"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نمونہ متن: %1$@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "示例文本： %1$@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出文件"
           }
         }
       }
     },
-    "select_json" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اختر JSON"
+    "installed_voices": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الأصوات المثبتة"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "JSON নির্বাচন করুন"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ইনস্টল করা ভয়েস"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "JSON auswählen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installierte Stimmen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select JSON"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installed Voices"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar JSON"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voces instaladas"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionner JSON"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voix installées"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "JSON चुनें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इंस्टॉल की गई आवाज़ें"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "JSON kiválasztása"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telepített hangok"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pilih JSON"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suara Terinstal"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleziona JSON"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voci installate"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "JSON を選択"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール済みの音声"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecteer JSON"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geïnstalleerde stemmen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wybierz JSON"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zainstalowane głosy"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Välj JSON"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installerade röster"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecionar JSON"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vozes Instaladas"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "JSON'u seçin"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yüklenen Sesler"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Виберіть JSON"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Встановлені Голоси"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "JSON کو منتخب کریں۔"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انسٹال شدہ آوازیں۔"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择 JSON"
-          }
-        }
-      }
-    },
-    "select_model" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اختر النموذج"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "মডেল নির্বাচন করুন"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell auswählen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select Model"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar modelo"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionner le modèle"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "मॉडल चुनें"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell kiválasztása"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pilih Model"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleziona modello"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "モデルを選択"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecteer model"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wybierz model"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Välj modell"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecionar Modelo"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Model Seç"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Виберіть модель"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ماڈل منتخب کریں۔"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择模型"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安装的声音"
           }
         }
       }
     },
-    "share_feedback" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مشاركة الملاحظات"
+    "json_error_data_corrupted_%@": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "البيانات تالفة: %@"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ফিডব্যাক শেয়ার করুন"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "তথ্য দূষিত: %@"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feedback teilen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Daten sind beschädigt: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Share Feedback"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The data is corrupted: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compartir comentarios"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los datos están dañados: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Partager un avis"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les données sont corrompues : %@"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "प्रतिक्रिया साझा करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डेटा दूषित है: %@"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Visszajelzés küldése"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Az adatok sérültek: %@"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bagikan Umpan Balik"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data korup: %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Condividi feedback"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I dati sono corrotti: %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "フィードバックを共有"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "データが破損しています: %@"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deel feedback"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De gegevens zijn beschadigd: %@"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wyślij opinię"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dane są uszkodzone: %@"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dela feedback"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datan är korrupt: %@"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compartilhar Feedback"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os dados estão corrompidos: %@"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geri Bildirim Paylaş"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veriler bozulmuş: %@"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Поділитися Відгуком"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дані пошкоджені: %@"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فیڈ بیک شیئر کریں۔"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈیٹا کرپٹ ہے: %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "分享反馈"
-          }
-        }
-      }
-    },
-    "speaker" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "المتحدث"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "স্পিকার"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprecher"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speaker"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Locutor"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interlocuteur"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "वक्ता"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beszélő"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speaker"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voce"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "話者"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spreker"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Głośnik"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Röst"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Locutor"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hoparlör"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Голос"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "متکلم"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "扬声器"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "数据已损坏：%@"
           }
         }
       }
     },
-    "stop" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إيقاف"
+    "json_error_invalid_model_file_path": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسار ملف النموذج غير صالح."
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "থামুন"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "অবৈধ মডেল ফাইল পাথ।"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stopp"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiger Modell-Dateipfad."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid model file path."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detener"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruta del archivo del modelo no válida."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arrêter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chemin du fichier de modèle invalide."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "रोकें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अमान्य मॉडल फ़ाइल पथ।"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Érvénytelen modellfájl elérési út."
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Berhenti"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jalur berkas model tidak valid."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Percorso del file del modello non valido."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モデルファイルのパスが無効です。"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ongeldig bestandspad voor model."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nieprawidłowa ścieżka do pliku modelu."
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stoppa"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ogiltig filsökväg för modell."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parar"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caminho de arquivo de modelo inválido."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Durdur"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geçersiz model dosya yolu."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Зупинити"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Недійсний шлях до файлу моделі."
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "رک جاؤ"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غلط ماڈل فائل پاتھ۔"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止"
-          }
-        }
-      }
-    },
-    "stop_playing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إيقاف التشغيل"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "প্লে করা বন্ধ করুন"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wiedergabe stoppen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop Playing"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detener reproducción"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arrêter la lecture"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "बजाना बंद करें"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lejátszás leállítása"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Berhenti Memutar"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interrompi riproduzione"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再生を停止"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop afspelen"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zatrzymaj odtwarzanie"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sluta spela"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parar Reprodução"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oynatmayı Durdur"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Зупинити відтворення"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "کھیلنا بند کرو"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止播放"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模型文件路径无效。"
           }
         }
       }
     },
-    "uninstall_button" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إزالة"
+    "json_error_missing_field_%@_at_%@": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الحقل ‘%@’ مفقود في ‘%@’"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "সরান"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‘%@’ ক্ষেত্রটি ‘%@’ এ অনুপস্থিত"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entfernen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Feld ‘%@’ fehlt bei ‘%@’"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The field ‘%@’ is missing at ‘%@’"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falta el campo ‘%@’ en ‘%@’"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Supprimer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le champ ‘%@’ est manquant à ‘%@’"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "हटाएं"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‘%@’ फ़ील्ड ‘%@’ पर गायब है"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eltávolítás"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A(z) ‘%@’ mező hiányzik itt: ‘%@’"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hapus"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bidang ‘%@’ tidak ditemukan di ‘%@’"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rimuovi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il campo ‘%@’ è mancante in ‘%@’"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "削除"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‘%@’ フィールドが ‘%@’ に見つかりません"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwijder"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Het veld ‘%@’ ontbreekt bij ‘%@’"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usuń"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pole „%@” nie występuje w „%@”"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ta bort"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fältet ‘%@’ saknas vid ‘%@’"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remover"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O campo ‘%@’ está faltando em ‘%@’"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaldır"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "‘%@’ alanı ‘%@’ konumunda eksik."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Видалити"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поле «%@» відсутнє у «%@»"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ہٹا دیں۔"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فیلڈ '%@' '%@' پر غائب ہے"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "删除"
-          }
-        }
-      }
-    },
-    "uninstall_voice" : {
-      "comment" : "A button label that uninstalls the voice assistant.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إزالة نموذج الصوت"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ভয়েস মডেল সরান"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprachmodell entfernen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove Voice Model"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminar modelo de voz"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Supprimer le modèle de voix"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "वॉयस मॉडल हटाएं"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hangmodell eltávolítása"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hapus Model Suara"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rimuovi modello vocale"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音声モデルを削除"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwijder spraakmodel"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usuń model głosu"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ta bort röstmodell"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remover Modelo de Voz"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ses Modelini Kaldır"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Видалити голосову модель"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "وائس ماڈل کو ہٹا دیں۔"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "删除语音模型"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "字段“%@”在“%@”处缺失"
           }
         }
       }
     },
-    "update_model_in_app" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "استيراد نموذج من الملفات"
+    "json_error_type_mismatch_%@_at_%@": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "توقع قيمة من نوع '%@' في '%@'، ولكن وجد شيء آخر."
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ফাইল থেকে মডেল ইমপোর্ট করুন"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "'%@' এ '%@' টাইপের মান প্রত্যাশিত ছিল, কিন্তু অন্য কিছু পাওয়া গেছে।"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell aus Dateien importieren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wert vom Typ '%@' bei '%@' erwartet, aber etwas anderes gefunden."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Import Model from Files"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expected a value of type '%@' at '%@', but found something else."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importar modelo desde archivos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se esperaba un valor de tipo '%@' en '%@', pero se encontró otra cosa."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importer le modèle depuis les fichiers"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valeur de type '%@' attendue à '%@', mais autre chose a été trouvé."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "फ़ाइलों से मॉडल आयात करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "'%@' पर '%@' प्रकार के मान की अपेक्षा थी, लेकिन कुछ और मिला।"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modell importálása fájlokból"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "'%@' típusú értéket vártunk a(z) '%@' helyen, de mást találtunk."
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impor Model dari Berkas"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mengharapkan nilai tipe '%@' di '%@', tetapi menemukan hal lain."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importa modello da file"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atteso un valore di tipo '%@' in '%@', ma è stato trovato altro."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ファイルからモデルをインポート"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "'%@' にタイプ '%@' の値が期待されましたが、別のものが見つかりました。"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importeer model uit bestanden"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwachtte een waarde van type '%@' bij '%@', maar vond iets anders."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importuj model z plików"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oczekiwano wartości typu '%@' w '%@', ale znaleziono coś innego."
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importera modell från filer"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Väntade ett värde av typen '%@' vid '%@', men hittade något annat."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importar Modelo de Arquivos"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esperava um valor do tipo '%@' em '%@', mas encontrou outra coisa."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dosyalardan Model İçe Aktar"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "'%@' konumunda '%@' türünde bir değer bekleniyordu, ancak başka bir şey bulundu."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Імпортувати з файлів"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очікувалося значення типу '%@' у '%@', але знайдено щось інше."
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فائلوں سے ماڈل درآمد کریں۔"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "'%@' پر '%@' قسم کی قدر کی توقع تھی، لیکن کچھ اور ملا۔"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "从文件导入模型"
-          }
-        }
-      }
-    },
-    "version" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الإصدار"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "সংস্করণ"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "वर्शन"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verzió"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versi"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versione"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "バージョン"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versie"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wersja"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versão"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sürüm"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Версія"
-          }
-        },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ورژن"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "版本"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "预期在“%@”处找到类型为“%@”的值，但找到的是其他类型。"
           }
         }
       }
     },
-    "voice_loading_progress_%@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تقدم التحميل %@%"
+    "json_error_value_not_found_%@_at_%@": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "القيمة المطلوبة من نوع '%@' كانت فارغة في '%@'."
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ডাউনলোডের অগ্রগতি %@%"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "'%@' এ '%@' টাইপের প্রয়োজনীয় মানটি শূন্য ছিল।"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download-Fortschritt %@%"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erforderlicher Wert vom Typ '%@' war null bei '%@'."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "downloading progress %@%"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Required value of type '%@' was null at '%@'."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "progreso de descarga %@%"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El valor requerido de tipo '%@' era nulo en '%@'."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "progression du téléchargement %@%"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La valeur requise de type '%@' était nulle à '%@'."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "डाउनलोडिंग प्रगति %@%"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "'%@' प्रकार का आवश्यक मान '%@' पर शून्य (null) था।"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "letöltési folyamat %@%"
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A(z) '%@' típusú kötelező érték null volt itt: '%@'."
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "progres mengunduh %@%"
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nilai yang diperlukan dari tipe '%@' adalah null di '%@'."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "progresso download %@%"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il valore richiesto di tipo '%@' era nullo in '%@'."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダウンロードの進行状況 %@%"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "'%@' に必要なタイプ '%@' の値が NULL でした。"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "download voortgang %@%"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vereiste waarde van type '%@' was null bij '%@'."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "postęp pobierania %@%"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wymagana wartość typu '%@' była równa null dla '%@'."
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "nedladdningsframsteg %@%"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nödvändigt värde av typen '%@' saknades vid '%@'."
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "progresso do download %@%"
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O valor obrigatório do tipo '%@' era nulo em '%@'."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "indirme ilerlemesi %@%"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "'%@' türündeki gerekli değer '%@' konumunda boştu."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "прогрес завантаження %@%"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Необхідне значення типу '%@' було null у '%@'."
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ڈاؤن لوڈنگ کی پیشرفت %@%"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قسم '%@' کی مطلوبہ قدر '%@' پر کالعدم تھی۔"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在下载进度 %@%"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "类型为“%@”的必需值为空。"
           }
         }
       }
     },
-    "warning_big_voice_files" : {
-      "comment" : "A warning message about the size of voice files.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ملاحظة: يمكن أن تكون ملفات الصوت كبيرة. لتجنب رسوم إضافية، قم بالتحميل باستخدام Wi-Fi أو خطة بيانات غير محدودة."
+    "language": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اللغة"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "দ্রষ্টব্য: ভয়েস ফাইলগুলি বড় হতে পারে। অতিরিক্ত খরচ এড়াতে, Wi-Fi বা আনলিমিটেড ডেটা প্ল্যান ব্যবহার করে ডাউনলোড করুন।"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ভাষা"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hinweis: Sprachdateien können groß sein. Um zusätzliche Gebühren zu vermeiden, lade sie über WLAN oder einen unbegrenzten Datentarif herunter."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Note: Voice files can be large. To avoid extra charges, download using Wi-Fi or an unlimited data plan."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Language"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nota: Los archivos de voz pueden ser grandes. Para evitar cargos adicionales, descárgalos usando Wi-Fi o un plan de datos ilimitado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idioma"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remarque : Les fichiers vocaux peuvent être volumineux. Pour éviter des frais supplémentaires, téléchargez-les via Wi-Fi ou un forfait de données illimité."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Langue"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "नोट: वॉयस फ़ाइलें बड़ी हो सकती हैं। अतिरिक्त शुल्क से बचने के लिए, वाई-फाई या असीमित डेटा प्लान का उपयोग करके डाउनलोड करें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "भाषा"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Megjegyzés: A hangfájlok mérete nagy lehet. A pluszköltségek elkerülése érdekében javasoljuk, hogy Wi-Fi-n vagy korlátlan adatforgalmi csomagon keresztül töltse le azokat."
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nyelv"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Catatan: Berkas suara bisa berukuran besar. Untuk menghindari biaya tambahan, unduh menggunakan Wi-Fi atau paket data tak terbatas."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lingua"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nota: I file vocali possono essere grandi. Per evitare costi aggiuntivi, scarica utilizzando il Wi-Fi o un piano dati illimitato."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "言語"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "注意：音声ファイルは大きくなる場合があります。追加料金を避けるために、Wi-Fi または無制限のデータプランを使用してダウンロードしてください。"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taal"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opmerking: Spraakbestanden kunnen groot zijn. Om extra kosten te vermijden, download je via wifi of een onbeperkt data-abonnement."
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bahasa"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uwaga: Pliki głosowe mogą być duże. Aby uniknąć dodatkowych opłat, pobieraj przez Wi-Fi lub z nielimitowanym pakietem danych."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Język"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obs: Röstfiler kan vara stora. För att undvika extra kostnader, ladda ner via Wi-Fi eller ett obegränsat datapaket."
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Språk"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nota: Arquivos de voz podem ser grandes. Para evitar cobranças extras, baixe usando Wi-Fi ou um plano de dados ilimitado."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idioma"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not: Ses dosyaları büyük olabilir. Ek ücretlerden kaçınmak için Wi-Fi veya sınırsız veri planı ile indirin."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dil"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Примітка: голосові файли можуть бути великими. Щоб уникнути додаткових витрат, завантажуйте через Wi-Fi або безлімітний тариф."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Мова"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نوٹ: صوتی فائلیں بڑی ہو سکتی ہیں۔ اضافی چارجز سے بچنے کے لیے، Wi-Fi یا لامحدود ڈیٹا پلان کا استعمال کرکے ڈاؤن لوڈ کریں۔"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زبان"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "注意：语音文件可能大。为了避免额外费用，请使用 Wi-Fi 或无限数据计划下载。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语言"
           }
         }
       }
     },
-    "warning_not_tested_voices" : {
-      "comment" : "A warning displayed below the list of available languages, reminding users that some voices have not been tested.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "هذه الأصوات مرفوعة من قبل المجتمع وقد لا تكون مختبرة بالكامل. قد تكون بعض الملفات غير مكتملة أو تتصرف بشكل غير متوقع. التحميل والتثبيت على مسؤوليتك الخاصة."
+    "languages": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اللغات"
           }
         },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "এই ভয়েসগুলি সম্প্রদায়-আপলোড করা এবং সম্পূর্ণরূপে পরীক্ষা করা নাও হতে পারে। কিছু ফাইল অসম্পূর্ণ হতে পারে বা অপ্রত্যাশিত আচরণ করতে পারে। আপনার নিজ দায়িত্বে ডাউনলোড এবং ইনস্টল করুন।"
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ভাষাগুলো"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diese Stimmen wurden von der Community hochgeladen und sind möglicherweise nicht vollständig getestet. Einige Dateien können unvollständig sein oder sich unerwartet verhalten. Download und Installation auf eigene Gefahr."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprachen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "These voices are community-uploaded and may not be fully tested. Some files may be incomplete or behave unexpectedly. Download and install at your own risk."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Languages"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estas voces han sido subidas por la comunidad y es posible que no se hayan probado por completo. Algunos archivos pueden estar incompletos o comportarse de forma inesperada. Descarga e instala bajo tu propia responsabilidad."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idiomas"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ces voix sont téléchargées par la communauté et peuvent ne pas être entièrement testées. Certains fichiers peuvent être incomplets ou se comporter de manière inattendue. Téléchargez et installez à vos propres risques."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Langues"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ये आवाज़ें समुदाय द्वारा अपलोड की गई हैं और हो सकता है कि इनका पूरी तरह से परीक्षण न किया गया हो। कुछ फ़ाइलें अधूरी हो सकती हैं या अप्रत्याशित व्यवहार कर सकती हैं। अपने जोखिम पर डाउनलोड और इंस्टॉल करें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "भाषाएँ"
           }
         },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ezeket a hangokat a közösség töltötte fel, és előfordulhat, hogy nem tesztelték őket teljes körűen. Egyes fájlok hiányosak lehetnek, vagy váratlanul működhetnek. Letöltés és telepítés saját felelősségre."
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nyelvek"
           }
         },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suara-suara ini diunggah oleh komunitas dan mungkin belum diuji sepenuhnya. Beberapa berkas mungkin tidak lengkap atau berperilaku tidak terduga. Unduh dan instal atas risiko Anda sendiri."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lingue"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Queste voci sono caricate dalla comunità e potrebbero non essere state testate completamente. Alcuni file potrebbero essere incompleti o comportarsi in modo inaspettato. Scarica e installa a tuo rischio e pericolo."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "言語"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "これらの音声はコミュニティによってアップロードされたものであり、完全にテストされていない可能性があります。一部のファイルが不完全であったり、予期しない動作をしたりする場合があります。ご自身の責任でダウンロードしてインストールしてください。"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talen"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deze stemmen zijn geüpload door de community en zijn mogelijk niet volledig getest. Sommige bestanden kunnen onvolledig zijn of zich onverwacht gedragen. Downloaden en installeren is op eigen risico."
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bahasa"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Te głosy zostały przesłane przez społeczność i mogą nie być w pełni przetestowane. Niektóre pliki mogą być niekompletne lub działać nieprawidłowo. Pobieraj i instaluj na własne ryzyko."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Języki"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dessa röster är uppladdade av communityn och har kanske inte testats fullständigt. Vissa filer kan vara ofullständiga eller bete sig oväntat. Ladda ner och installera på egen risk."
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Språk"
           }
         },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estas vozes são enviadas pela comunidade e podem não estar totalmente testadas. Alguns arquivos podem estar incompletos ou se comportar de forma inesperada. Baixe e instale por sua conta e risco."
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idiomas"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bu sesler topluluk tarafından yüklenmiştir ve tamamen test edilmemiş olabilir. Bazı dosyalar eksik veya beklenmedik şekilde davranabilir. Kendi riskinizle indirin ve yükleyin."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diller"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ці голоси додані спільнотою та можуть бути недостатньо протестовані. Деякі файли можуть бути неповними або працювати нестабільно. Завантажуйте та встановлюйте на свій ризик."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Мови"
           }
         },
-        "ur-PK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "یہ آوازیں کمیونٹی کے ذریعے اپ لوڈ کی گئی ہیں اور ہو سکتا ہے کہ ان کا مکمل تجربہ نہ کیا جائے۔ کچھ فائلیں نامکمل ہو سکتی ہیں یا غیر متوقع طور پر برتاؤ کرتی ہیں۔ اپنی ذمہ داری پر ڈاؤن لوڈ اور انسٹال کریں۔"
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زبانیں"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "这些声音是社区上传的，可能不会完全测试。一些文件可能不完整或出乎意料。下载并安装您自己承担的风险。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语言"
+          }
+        }
+      }
+    },
+    "license_audio_unit_description": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ملحق وحدة الصوت هذا، الذي يتضمن eSpeak-NG و Piper1-GPL، مرخص تحت GPLv3."
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এই অডিও ইউনিট এক্সটেন্সন, যার মধ্যে eSpeak-NG এবং Piper1-GPL অন্তর্ভুক্ত রয়েছে, GPLv3 এর অধীনে লাইসেন্সপ্রাপ্ত।"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Audio-Unit-Erweiterung, die eSpeak-NG und Piper1-GPL enthält, ist unter der GPLv3 lizenziert."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This Audio Unit Extension, which includes eSpeak-NG and Piper1-GPL, is licensed under GPLv3."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta extensión de Audio Unit, que incluye eSpeak-NG y Piper1-GPL, tiene licencia GPLv3."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cette extension Audio Unit, qui inclut eSpeak-NG et Piper1-GPL, est sous licence GPLv3."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "यह ऑडियो यूनिट एक्सटेंशन, जिसमें eSpeak-NG और Piper1-GPL शामिल हैं, GPLv3 के तहत लाइसेंस प्राप्त है।"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ez az Audio Unit bővítmény, amely tartalmazza az eSpeak-NG-t és a Piper1-GPL-t, a GPLv3 licenc alatt áll."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ekstensi Unit Audio ini, yang mencakup eSpeak-NG dan Piper1-GPL, dilisensikan di bawah GPLv3."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questa estensione Audio Unit, che include eSpeak-NG e Piper1-GPL, è concessa in licenza sotto GPLv3."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak-NG と Piper1-GPL を含むこの Audio Unit 拡張機能は、GPLv3 に基づいてライセンスされています。"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deze Audio Unit-extensie, inclusief eSpeak-NG en Piper1-GPL, is gelicentieerd onder GPLv3."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To rozszerzenie Audio Unit, które zawiera eSpeak-NG i Piper1-GPL, jest licencjonowane na GPLv3."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detta Audio Unit-tillägg, som inkluderar eSpeak-NG och Piper1-GPL, är licensierat under GPLv3."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta Extensão de Unidade de Áudio, que inclui eSpeak-NG e Piper1-GPL, é licenciada sob a GPLv3."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak-NG ve Piper1-GPL içeren bu Ses Birimi Eklentisi GPLv3 lisanslıdır."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Цей Audio Unit Extension, що включає eSpeak-NG та Piper1-GPL, ліцензований за GPLv3."
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "یہ آڈیو یونٹ ایکسٹینشن، جس میں eSpeak-NG اور Piper1-GPL شامل ہیں، GPLv3 کے تحت  لائسنس یافتہ ہے۔"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此音频单元扩展包括eSpeak-NG和 Piper1-GPL，它是GPLv3授权的。"
+          }
+        }
+      }
+    },
+    "license_audio_unit_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ملحق وحدة الصوت (GPLv3)"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "অডিও ইউনিট এক্সটেনশন (GPLv3)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio-Unit-Erweiterung (GPLv3)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio Unit Extension (GPLv3)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extensión de Audio Unit (GPLv3)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extension Audio Unit (GPLv3)"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ऑडियो यूनिट एक्सटेंशन (GPLv3)"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio Unit bővítmény (GPLv3)"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ekstensi Unit Audio (GPLv3)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estensione Audio Unit (GPLv3)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio Unit 拡張機能 (GPLv3)"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio Unit-extensie (GPLv3)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozszerzenie Audio Unit (GPLv3)"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio Unit-tillägg (GPLv3)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extensão de Unidade de Áudio (GPLv3)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ses Birimi Eklentisi (GPLv3)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio Unit Extension (GPLv3)"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آڈیو یونٹ ایکسٹینشن (GPLv3)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音频单元扩展 (GPLv3)"
+          }
+        }
+      }
+    },
+    "license_espeak_ng_description": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak NG هو محرك نطق خفيف الوزن ومفتوح المصدر يدعم أكثر من 100 لغة ولهجة."
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak NG একটি হালকা ওপেন-সোর্স টেক্সট-টু-স্পিচ ইঞ্জিন যা ১০০টিরও বেশি ভাষা এবং অ্যাকসেন্ট সমর্থন করে।"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak NG ist eine leichtgewichtige Open-Source-Text-to-Speech-Engine, die über 100 Sprachen und Akzente unterstützt."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak NG is a lightweight open-source text-to-speech engine supporting over 100 languages and accents."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak NG es un motor de texto a voz de código abierto y ligero que admite más de 100 idiomas y acentos."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak NG est un moteur de synthèse vocale open source léger prenant en charge plus de 100 langues et accents."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak NG एक हल्का ओपन-सोर्स टेक्स्ट-टू-स्पीच इंजन है जो 100 से अधिक भाषाओं और लहजों का समर्थन करता है।"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Az eSpeak NG egy könnyű, nyílt forráskódú szövegfelolvasó motor, amely több mint 100 nyelvet és akcentust támogat."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak NG adalah mesin text-to-speech sumber terbuka ringan yang mendukung lebih dari 100 bahasa dan aksen."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak NG è un motore di sintesi vocale open source leggero che supporta oltre 100 lingue e accenti."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak NG は、100 以上の言語とアクセントをサポートする軽量のオープンソース テキスト読み上げエンジンです。"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak NG is een lichtgewicht open-source tekst-naar-spraak-engine die meer dan 100 talen en accenten ondersteunt."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak NG to lekki, otwartoźródłowy silnik TTS obsługujący ponad 100 języków i akcentów."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak NG är en lättviktig text-till-tal-motor med öppen källkod som stöder över 100 språk och dialekter."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "o eSpeak NG é um mecanismo de conversão de texto em fala de código aberto leve que suporta mais de 100 idiomas e sotaques."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak NG, 100’den fazla dili ve aksanı destekleyen hafif açık kaynaklı bir metinden konuşmaya motorudur."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak NG - це швидкий механізм перетворення тексту в мовлення з відкритим кодом, який підтримує понад 100 мов та акцентів."
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak NG ایک ہلکا پھلکا اوپن سورس ٹیکسٹ ٹو اسپیچ انجن ہے جو 100 سے زیادہ زبانوں اور لہجوں کو سپورٹ کرتا ہے۔"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eSpeak NG 是一个轻量开源文字转语音引擎，支持100多种语言和音量。"
+          }
+        }
+      }
+    },
+    "license_main_app_%@_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تطبيق Piper %@ (MIT)"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper %@ অ্যাপ (MIT)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper %@ App (MIT)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper %@ App (MIT)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicación Piper %@ (MIT)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Application Piper %@ (MIT)"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पाइपर %@ ऐप (MIT)"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper %@ alkalmazás (MIT)"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplikasi Piper %@ (MIT)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Piper %@ (MIT)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper %@ アプリ (MIT)"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper %@ App (MIT)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper %@ Aplikacja (MIT)"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper %@ App (MIT)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Piper %@ (MIT)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper %@ Uygulaması (MIT)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper %@ Додаток (MIT)"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper %@ App (MIT)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper %@ App (MIT)"
+          }
+        }
+      }
+    },
+    "license_main_app_description": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تطبيق Piper، الذي طوره [Ihor Shevchuk](https://ihor-shevchuk.dev)، مرخص تحت MIT. إنه برنامج منفصل ويتواصل مع ملحق وحدة الصوت فقط عبر XPC."
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[Ihor Shevchuk](https://ihor-shevchuk.dev) দ্বারা তৈরি পাইপার অ্যাপটি MIT এর অধীনে লাইসেন্সপ্রাপ্ত। এটি একটি পৃথক প্রোগ্রাম এবং শুধুমাত্র XPC এর মাধ্যমে অডিও ইউনিট এক্সটেন্সনের সাথে যোগাযোগ করে।"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Piper-App, entwickelt von Ihor Shevchuk, steht unter der MIT-Lizenz. Sie ist ein eigenständiges Programm und kommuniziert mit der Audio-Unit-Erweiterung ausschließlich über XPC."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper App, developed by [Ihor Shevchuk](https://ihor-shevchuk.dev), is licensed under MIT. It is a separate program and communicates with the Audio Unit Extension only via XPC."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La aplicación Piper, desarrollada por Ihor Shevchuk, tiene licencia MIT. Es un programa independiente y se comunica con la extensión de Audio Unit solo a través de XPC."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'application Piper, développée par Ihor Shevchuk, est sous licence MIT. Il s'agit d'un programme distinct qui communique avec l'extension Audio Unit uniquement via XPC."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पाइपर ऐप, Ihor Shevchuk द्वारा विकसित, MIT के तहत लाइसेंस प्राप्त है। यह एक अलग प्रोग्राम है और केवल XPC के माध्यम से ऑडियो यूनिट एक्सटेंशन के साथ संचार करता है।"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A Piper alkalmazás, amelyet Ihor Shevchuk fejlesztett ki, MIT licenc alatt áll. Ez egy különálló program, amely kizárólag XPC-n keresztül kommunikál az Audio Unit bővítménnyel."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplikasi Piper, dikembangkan oleh [Ihor Shevchuk](https://ihor-shevchuk.dev), dilisensikan di bawah MIT. Ini adalah program terpisah dan berkomunikasi dengan Ekstensi Unit Audio hanya melalui XPC."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'app Piper, sviluppata da Ihor Shevchuk, è concessa in licenza sotto MIT. È un programma separato e comunica con l'estensione Audio Unit solo tramite XPC."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ihor Shevchuk によって開発された Piper アプリは、MIT に基づいてライセンスされています。これは別のプログラムであり、XPC 経由でのみ Audio Unit 拡張機能と通信します。"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De Piper App, ontwikkeld door Ihor Shevchuk, is gelicentieerd onder MIT. Het is een apart programma en communiceert alleen via XPC met de Audio Unit-extensie."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplikacja Piper, stworzona przez [Ihora Szewczuka](https://ihor-shevchuk.dev), jest licencjonowana na MIT. To osobny program, który komunikuje się z rozszerzeniem Audio Unit wyłącznie przez XPC."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper App, utvecklad av Ihor Shevchuk, är licensierad under MIT. Det är ett separat program och kommunicerar endast med Audio Unit-tillägget via XPC."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O App Piper, desenvolvido por [Ihor Shevchuk](https://ihor-shevchuk.dev), é licenciado sob a MIT. É um programa separado e se comunica com a Extensão de Unidade de Áudio apenas via XPC."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[Ihor Shevchuk](https://ihor-shevchuk.dev) tarafından geliştirilen Piper Uygulaması MIT lisanslıdır. Bu ayrı bir programdır ve Ses Birimi Eklentisi ile yalnızca XPC üzerinden iletişim kurar."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Додаток Piper, розроблений [Ігорем Шевчуком](https://ihor-shevchuk.dev), ліцензований за MIT. Це окрема програма, яка взаємодіє з Audio Unit Extension лише через XPC."
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پائپر ایپ، جسے [Ihor Shevchuk](https://ihor-shevchuk.dev) نے تیار کیا ہے، MIT کے تحت لائسنس یافتہ ہے۔ یہ ایک الگ پروگرام ہے اور صرف XPC کے ذریعے آڈیو یونٹ ایکسٹینشن کے ساتھ بات چیت کرتا ہے۔"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper App 是由 [Ihor Shevchuk](https://ihor-shevchuk.dev) 开发的，是在 MIT 下授权的。这是一个单独的程序，仅通过 XPC 与音频设备扩展进行通信。"
+          }
+        }
+      }
+    },
+    "license_piper_description": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper هو محرك نطق عصبي سريع ومفتوح المصدر طوره مجتمع OHF-Voice."
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper হল একটি দ্রুত, ওপেন-সোর্স নিউরাল টেক্সট-টু-স্পিচ ইঞ্জিন যা OHF-Voice সম্প্রদায় দ্বারা তৈরি করা হয়েছে।"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper ist eine schnelle Open-Source-Neural-Text-to-Speech-Engine, die von der OHF-Voice-Community entwickelt wurde."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper is a fast, open-source neural text-to-speech engine developed by the OHF-Voice community."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper es un motor de texto a voz neuronal rápido y de código abierto desarrollado por la comunidad OHF-Voice."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper est un moteur de synthèse vocale neuronale rapide et open source développé par la communauté OHF-Voice."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पाइपर एक तेज़, ओपन-सोर्स न्यूरल टेक्स्ट-टू-स्पीच इंजन है जिसे OHF-Voice समुदाय द्वारा विकसित किया गया है।"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A Piper egy gyors, nyílt forráskódú neurális szövegfelolvasó motor, amelyet az OHF-Voice közösség fejlesztett ki."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper adalah mesin text-to-speech saraf sumber terbuka yang cepat yang dikembangkan oleh komunitas OHF-Voice."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper è un motore di sintesi vocale neurale veloce e open source sviluppato dalla comunità OHF-Voice."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper は、OHF-Voice コミュニティによって開発された高速でオープンソースのニューラル テキスト読み上げエンジンです。"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper is een snelle, open-source neurale tekst-naar-spraak-engine ontwikkeld door de OHF-Voice community."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper to szybki, otwartoźródłowy, neuronowy silnik TTS opracowany przez społeczność OHF-Voice."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper är en snabb röstmotor för text-till-tal baserad på neurala nätverk med öppen källkod, utvecklad av OHF-Voice-communityn."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Piper é um mecanismo de conversão de texto em fala neural rápido e de código aberto desenvolvido pela comunidade OHF-Voice."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper, OHF-Voice topluluğu tarafından geliştirilen hızlı, açık kaynaklı bir sinirsel metinden konuşmaya motorudur."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper — це швидкий двигун синтезу мовлення, розроблений OHF-Voice community. з відкритим кодом."
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پائپر ایک تیز، اوپن سورس نیورل ٹیکسٹ ٹو اسپیچ انجن ہے جسے OHF-Voice کمیونٹی نے تیار کیا ہے۔"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper是一个由OHF-Voice 社区开发的快速开放源码文字转语音引擎。"
+          }
+        }
+      }
+    },
+    "model": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نموذج"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "মডেল"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modèle"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मॉडल"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modello"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モデル"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelo"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Модель"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اے آئی ماڈل"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模型"
+          }
+        }
+      }
+    },
+    "no_voices": {
+      "comment": "A placeholder text to display when a language has no available voices.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد أصوات متاحة"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "কোনো ভয়েস উপলব্ধ নেই"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Stimmen verfügbar"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No voices available"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay voces disponibles"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune voix disponible"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कोई आवाज़ उपलब्ध नहीं है"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nem állnak rendelkezésre hangok"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tidak ada suara yang tersedia"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessuna voce disponibile"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用可能な音声はありません"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geen stemmen beschikbaar"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brak dostępnych głosów"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inga röster tillgängliga"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma voz disponível"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kullanılabilir ses yok"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Голосів немає"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کوئی آوازیں دستیاب نہیں ہیں۔"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有可用的声音"
+          }
+        }
+      }
+    },
+    "no_voices_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**لم يتم تثبيت أي أصوات بعد.**\nاستخدم زر **تحميل نموذج الصوت** أدناه لإضافة صوت."
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**এখনো কোনো ভয়েস ইনস্টল করা হয়নি।**\nএকটি ভয়েস যোগ করতে নিচের **ভয়েস মডেল ডাউনলোড করুন** বোতামটি ব্যবহার করুন।"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Es sind noch keine Stimmen installiert.**\nNutze die Schaltfläche **Sprachmodell herunterladen** unten, um eine Stimme hinzuzufügen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**No voices are installed yet.**\nUse the **Download Voice Model** button below to add a voice."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Aún no hay voces instaladas.**\nUsa el botón **Descargar modelo de voz** de abajo para añadir una voz."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Aucune voix n'est installée.**\nUtilisez le bouton **Télécharger le modèle de voix** ci-dessous pour ajouter une voix."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**अभी तक कोई आवाज़ इंस्टॉल नहीं की गई है।**\nआवाज़ जोड़ने के लिए नीचे दिए गए **वॉयस मॉडल डाउनलोड करें** बटन का उपयोग करें।"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Még nincsenek hangok telepítve.**\nHang hozzáadásához használja az alábbi **Hangmodell letöltése** gombot."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Belum ada suara yang diinstal.**\nGunakan tombol **Unduh Model Suara** di bawah ini untuk menambahkan suara."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Nessuna voce ancora installata.**\nUsa il pulsante **Scarica modello vocale** qui sotto per aggiungere una voce."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**音声がまだインストールされていません。**\n下の **音声モデルをダウンロード** ボタンを使用して音声を追加してください。"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Er zijn nog geen stemmen geïnstalleerd.**\nGebruik de knop **Download spraakmodel** hieronder om een stem toe te voegen."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Żadne głosy nie są jeszcze zainstalowane.**\nUżyj przycisku **Pobierz model głosu** poniżej, aby dodać głos."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Inga röster är installerade än.**\nAnvänd knappen **Ladda ner röstmodell** nedan för att lägga till en röst."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Nenhuma voz está instalada ainda.**\nUse o botão **Baixar Modelo de Voz** abaixo para adicionar uma voz."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Henüz hiçbir ses yüklenmedi.**\nBir ses eklemek için aşağıdaki **Ses Modelini İndir** düğmesini kullanın."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**Жодного голосу ще не встановлено.**  \nЩоб додати голос, скористайтеся кнопкою **Завантажити голосову модель** нижче."
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**ابھی تک کوئی آوازیں انسٹال نہیں ہیں۔**\nآواز شامل کرنے کے لیے نیچے **وائس ماڈل ڈاؤن لوڈ کریں** بٹن کا استعمال کریں۔"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "**尚未安装声音。**\n使用下面的 **下载语音模型** 按钮添加语音。"
+          }
+        }
+      }
+    },
+    "ok": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "موافق"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ঠিক আছে"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ok"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aceptar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ठीक है"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oke"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ok"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamam"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Гаразд"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹھیک ہے"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好的"
+          }
+        }
+      }
+    },
+    "onnx_file": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ملف ONNX"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ONNX ফাইল"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ONNX-Datei"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ONNX File"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archivo ONNX"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fichier ONNX"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ONNX फ़ाइल"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ONNX fájl"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Berkas ONNX"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File ONNX"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ONNX ファイル"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ONNX-bestand"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plik ONNX"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ONNX-fil"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arquivo ONNX"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ONNX Dosyası"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Файл ONNX"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ONNX فائل"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ONNX 文件"
+          }
+        }
+      }
+    },
+    "piper_app_name": {
+      "comment": "The title of the main view.",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पाइपर"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piper"
+          }
+        }
+      }
+    },
+    "play_sample": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تشغيل عينة"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "নমুনা প্লে করুন"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beispiel abspielen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play Sample"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproducir muestra"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lire l'échantillon"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नमूना बजाएं"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minta lejátszása"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Putar Sampel"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riproduci campione"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サンプルを再生"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speel voorbeeld af"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odtwórz próbkę"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spela prov"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproduzir Amostra"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Örnek Oynat"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відтворити приклад"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمونہ کھیلیں"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "播放示例"
+          }
+        }
+      }
+    },
+    "quality": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الجودة"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "গুণমান"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Qualität"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quality"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calidad"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Qualité"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "गुणवत्ता"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minőség"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kualitas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Qualità"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "品質"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kwaliteit"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jakość"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kvalitet"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Qualidade"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kalite"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Якість"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معیار"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "质量"
+          }
+        }
+      }
+    },
+    "sample_rate": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معدل العينة"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "স্যাম্পল রেট"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abtastrate"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sample Rate"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frecuencia de muestreo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taux d'échantillonnage"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सैंपल रेट"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mintavételezési gyakoriság"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laju Sampel"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frequenza di campionamento"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サンプリングレート"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Samplefrequentie"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Częstotliwość próbkowania"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Samplingsfrekvens"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taxa de Amostragem"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Örnekleme Hızı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Частота"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمونہ کی شرح"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "采样率"
+          }
+        }
+      }
+    },
+    "sample_text": {
+      "comment": "A text field for entering sample text.",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نص العينة"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "নমুনা টেক্সট"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beispieltext"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sample Text"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Texto de muestra"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Texte d'exemple"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नमूना पाठ"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mintaszöveg"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teks Sampel"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testo di esempio"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サンプルテキスト"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voorbeeldtekst"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przykładowy tekst"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exempeltext"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Texto de Amostra"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Örnek Metin"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Текст прикладу"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمونہ متن"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "示例文本"
+          }
+        }
+      }
+    },
+    "sample_text: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نص العينة: %1$@"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "নমুনা টেক্সট: %1$@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beispieltext: %1$@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sample Text: %1$@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Texto de muestra: %1$@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Texte d'exemple : %1$@"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नमूना पाठ: %1$@"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mintaszöveg: %1$@"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teks Sampel: %1$@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testo di esempio: %1$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サンプルテキスト: %1$@"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voorbeeldtekst: %1$@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przykładowy tekst: %1$@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exempeltext: %1$@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Texto de Amostra: %1$@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Örnek Metin: %1$@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приклад: %1$@"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمونہ متن: %1$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "示例文本： %1$@"
+          }
+        }
+      }
+    },
+    "select_json": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اختر JSON"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON নির্বাচন করুন"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON auswählen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select JSON"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar JSON"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionner JSON"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON चुनें"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON kiválasztása"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pilih JSON"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleziona JSON"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON を選択"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecteer JSON"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wybierz JSON"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Välj JSON"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecionar JSON"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON'u seçin"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виберіть JSON"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON کو منتخب کریں۔"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择 JSON"
+          }
+        }
+      }
+    },
+    "select_model": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اختر النموذج"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "মডেল নির্বাচন করুন"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell auswählen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Model"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar modelo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionner le modèle"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मॉडल चुनें"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell kiválasztása"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pilih Model"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleziona modello"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モデルを選択"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecteer model"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wybierz model"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Välj modell"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecionar Modelo"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model Seç"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виберіть модель"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ماڈل منتخب کریں۔"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择模型"
+          }
+        }
+      }
+    },
+    "share_feedback": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مشاركة الملاحظات"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ফিডব্যাক শেয়ার করুন"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback teilen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share Feedback"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compartir comentarios"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Partager un avis"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "प्रतिक्रिया साझा करें"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visszajelzés küldése"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bagikan Umpan Balik"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Condividi feedback"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フィードバックを共有"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deel feedback"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyślij opinię"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dela feedback"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compartilhar Feedback"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geri Bildirim Paylaş"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поділитися Відгуком"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فیڈ بیک شیئر کریں۔"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分享反馈"
+          }
+        }
+      }
+    },
+    "speaker": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المتحدث"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "স্পিকার"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprecher"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speaker"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Locutor"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interlocuteur"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वक्ता"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beszélő"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speaker"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voce"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "話者"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spreker"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Głośnik"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Röst"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Locutor"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hoparlör"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Голос"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "متکلم"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "扬声器"
+          }
+        }
+      }
+    },
+    "stop": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إيقاف"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "থামুন"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stopp"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detener"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrêter"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रोकें"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Berhenti"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stoppa"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parar"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Durdur"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зупинити"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رک جاؤ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止"
+          }
+        }
+      }
+    },
+    "stop_playing": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إيقاف التشغيل"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "প্লে করা বন্ধ করুন"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiedergabe stoppen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop Playing"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detener reproducción"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrêter la lecture"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बजाना बंद करें"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lejátszás leállítása"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Berhenti Memutar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interrompi riproduzione"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再生を停止"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop afspelen"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zatrzymaj odtwarzanie"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sluta spela"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parar Reprodução"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oynatmayı Durdur"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зупинити відтворення"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کھیلنا بند کرو"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止播放"
+          }
+        }
+      }
+    },
+    "uninstall_button": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "সরান"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हटाएं"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eltávolítás"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hapus"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovi"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwijder"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ta bort"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaldır"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалити"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہٹا دیں۔"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除"
+          }
+        }
+      }
+    },
+    "uninstall_voice": {
+      "comment": "A button label that uninstalls the voice assistant.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة نموذج الصوت"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ভয়েস মডেল সরান"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprachmodell entfernen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove Voice Model"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar modelo de voz"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer le modèle de voix"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वॉयस मॉडल हटाएं"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hangmodell eltávolítása"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hapus Model Suara"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovi modello vocale"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声モデルを削除"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwijder spraakmodel"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń model głosu"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ta bort röstmodell"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover Modelo de Voz"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ses Modelini Kaldır"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалити голосову модель"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وائس ماڈل کو ہٹا دیں۔"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除语音模型"
+          }
+        }
+      }
+    },
+    "update_model_in_app": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استيراد نموذج من الملفات"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ফাইল থেকে মডেল ইমপোর্ট করুন"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell aus Dateien importieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import Model from Files"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar modelo desde archivos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importer le modèle depuis les fichiers"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "फ़ाइलों से मॉडल आयात करें"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell importálása fájlokból"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impor Model dari Berkas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importa modello da file"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルからモデルをインポート"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importeer model uit bestanden"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importuj model z plików"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importera modell från filer"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar Modelo de Arquivos"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dosyalardan Model İçe Aktar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Імпортувати з файлів"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فائلوں سے ماڈل درآمد کریں۔"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从文件导入模型"
+          }
+        }
+      }
+    },
+    "version": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإصدار"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "সংস্করণ"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वर्शन"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verzió"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versi"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versione"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バージョン"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versie"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wersja"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versão"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sürüm"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Версія"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ورژن"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版本"
+          }
+        }
+      }
+    },
+    "voice_loading_progress_%@": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تقدم التحميل %@%"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ডাউনলোডের অগ্রগতি %@%"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download-Fortschritt %@%"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "downloading progress %@%"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "progreso de descarga %@%"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "progression du téléchargement %@%"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डाउनलोडिंग प्रगति %@%"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "letöltési folyamat %@%"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "progres mengunduh %@%"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "progresso download %@%"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダウンロードの進行状況 %@%"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "download voortgang %@%"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "postęp pobierania %@%"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nedladdningsframsteg %@%"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "progresso do download %@%"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "indirme ilerlemesi %@%"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "прогрес завантаження %@%"
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈاؤن لوڈنگ کی پیشرفت %@%"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在下载进度 %@%"
+          }
+        }
+      }
+    },
+    "warning_big_voice_files": {
+      "comment": "A warning message about the size of voice files.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ملاحظة: يمكن أن تكون ملفات الصوت كبيرة. لتجنب رسوم إضافية، قم بالتحميل باستخدام Wi-Fi أو خطة بيانات غير محدودة."
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "দ্রষ্টব্য: ভয়েস ফাইলগুলি বড় হতে পারে। অতিরিক্ত খরচ এড়াতে, Wi-Fi বা আনলিমিটেড ডেটা প্ল্যান ব্যবহার করে ডাউনলোড করুন।"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinweis: Sprachdateien können groß sein. Um zusätzliche Gebühren zu vermeiden, lade sie über WLAN oder einen unbegrenzten Datentarif herunter."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note: Voice files can be large. To avoid extra charges, download using Wi-Fi or an unlimited data plan."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nota: Los archivos de voz pueden ser grandes. Para evitar cargos adicionales, descárgalos usando Wi-Fi o un plan de datos ilimitado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remarque : Les fichiers vocaux peuvent être volumineux. Pour éviter des frais supplémentaires, téléchargez-les via Wi-Fi ou un forfait de données illimité."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नोट: वॉयस फ़ाइलें बड़ी हो सकती हैं। अतिरिक्त शुल्क से बचने के लिए, वाई-फाई या असीमित डेटा प्लान का उपयोग करके डाउनलोड करें।"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Megjegyzés: A hangfájlok mérete nagy lehet. A pluszköltségek elkerülése érdekében javasoljuk, hogy Wi-Fi-n vagy korlátlan adatforgalmi csomagon keresztül töltse le azokat."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catatan: Berkas suara bisa berukuran besar. Untuk menghindari biaya tambahan, unduh menggunakan Wi-Fi atau paket data tak terbatas."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nota: I file vocali possono essere grandi. Per evitare costi aggiuntivi, scarica utilizzando il Wi-Fi o un piano dati illimitato."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "注意：音声ファイルは大きくなる場合があります。追加料金を避けるために、Wi-Fi または無制限のデータプランを使用してダウンロードしてください。"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opmerking: Spraakbestanden kunnen groot zijn. Om extra kosten te vermijden, download je via wifi of een onbeperkt data-abonnement."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uwaga: Pliki głosowe mogą być duże. Aby uniknąć dodatkowych opłat, pobieraj przez Wi-Fi lub z nielimitowanym pakietem danych."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obs: Röstfiler kan vara stora. För att undvika extra kostnader, ladda ner via Wi-Fi eller ett obegränsat datapaket."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nota: Arquivos de voz podem ser grandes. Para evitar cobranças extras, baixe usando Wi-Fi ou um plano de dados ilimitado."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not: Ses dosyaları büyük olabilir. Ek ücretlerden kaçınmak için Wi-Fi veya sınırsız veri planı ile indirin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Примітка: голосові файли можуть бути великими. Щоб уникнути додаткових витрат, завантажуйте через Wi-Fi або безлімітний тариф."
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نوٹ: صوتی فائلیں بڑی ہو سکتی ہیں۔ اضافی چارجز سے بچنے کے لیے، Wi-Fi یا لامحدود ڈیٹا پلان کا استعمال کرکے ڈاؤن لوڈ کریں۔"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "注意：语音文件可能大。为了避免额外费用，请使用 Wi-Fi 或无限数据计划下载。"
+          }
+        }
+      }
+    },
+    "warning_not_tested_voices": {
+      "comment": "A warning displayed below the list of available languages, reminding users that some voices have not been tested.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هذه الأصوات مرفوعة من قبل المجتمع وقد لا تكون مختبرة بالكامل. قد تكون بعض الملفات غير مكتملة أو تتصرف بشكل غير متوقع. التحميل والتثبيت على مسؤوليتك الخاصة."
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এই ভয়েসগুলি সম্প্রদায়-আপলোড করা এবং সম্পূর্ণরূপে পরীক্ষা করা নাও হতে পারে। কিছু ফাইল অসম্পূর্ণ হতে পারে বা অপ্রত্যাশিত আচরণ করতে পারে। আপনার নিজ দায়িত্বে ডাউনলোড এবং ইনস্টল করুন।"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Stimmen wurden von der Community hochgeladen und sind möglicherweise nicht vollständig getestet. Einige Dateien können unvollständig sein oder sich unerwartet verhalten. Download und Installation auf eigene Gefahr."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "These voices are community-uploaded and may not be fully tested. Some files may be incomplete or behave unexpectedly. Download and install at your own risk."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estas voces han sido subidas por la comunidad y es posible que no se hayan probado por completo. Algunos archivos pueden estar incompletos o comportarse de forma inesperada. Descarga e instala bajo tu propia responsabilidad."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ces voix sont téléchargées par la communauté et peuvent ne pas être entièrement testées. Certains fichiers peuvent être incomplets ou se comporter de manière inattendue. Téléchargez et installez à vos propres risques."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ये आवाज़ें समुदाय द्वारा अपलोड की गई हैं और हो सकता है कि इनका पूरी तरह से परीक्षण न किया गया हो। कुछ फ़ाइलें अधूरी हो सकती हैं या अप्रत्याशित व्यवहार कर सकती हैं। अपने जोखिम पर डाउनलोड और इंस्टॉल करें।"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ezeket a hangokat a közösség töltötte fel, és előfordulhat, hogy nem tesztelték őket teljes körűen. Egyes fájlok hiányosak lehetnek, vagy váratlanul működhetnek. Letöltés és telepítés saját felelősségre."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suara-suara ini diunggah oleh komunitas dan mungkin belum diuji sepenuhnya. Beberapa berkas mungkin tidak lengkap atau berperilaku tidak terduga. Unduh dan instal atas risiko Anda sendiri."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Queste voci sono caricate dalla comunità e potrebbero non essere state testate completamente. Alcuni file potrebbero essere incompleti o comportarsi in modo inaspettato. Scarica e installa a tuo rischio e pericolo."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "これらの音声はコミュニティによってアップロードされたものであり、完全にテストされていない可能性があります。一部のファイルが不完全であったり、予期しない動作をしたりする場合があります。ご自身の責任でダウンロードしてインストールしてください。"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deze stemmen zijn geüpload door de community en zijn mogelijk niet volledig getest. Sommige bestanden kunnen onvolledig zijn of zich onverwacht gedragen. Downloaden en installeren is op eigen risico."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Te głosy zostały przesłane przez społeczność i mogą nie być w pełni przetestowane. Niektóre pliki mogą być niekompletne lub działać nieprawidłowo. Pobieraj i instaluj na własne ryzyko."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dessa röster är uppladdade av communityn och har kanske inte testats fullständigt. Vissa filer kan vara ofullständiga eller bete sig oväntat. Ladda ner och installera på egen risk."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estas vozes são enviadas pela comunidade e podem não estar totalmente testadas. Alguns arquivos podem estar incompletos ou se comportar de forma inesperada. Baixe e instale por sua conta e risco."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu sesler topluluk tarafından yüklenmiştir ve tamamen test edilmemiş olabilir. Bazı dosyalar eksik veya beklenmedik şekilde davranabilir. Kendi riskinizle indirin ve yükleyin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ці голоси додані спільнотою та можуть бути недостатньо протестовані. Деякі файли можуть бути неповними або працювати нестабільно. Завантажуйте та встановлюйте на свій ризик."
+          }
+        },
+        "ur-PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "یہ آوازیں کمیونٹی کے ذریعے اپ لوڈ کی گئی ہیں اور ہو سکتا ہے کہ ان کا مکمل تجربہ نہ کیا جائے۔ کچھ فائلیں نامکمل ہو سکتی ہیں یا غیر متوقع طور پر برتاؤ کرتی ہیں۔ اپنی ذمہ داری پر ڈاؤن لوڈ اور انسٹال کریں۔"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这些声音是社区上传的，可能不会完全测试。一些文件可能不完整或出乎意料。下载并安装您自己承担的风险。"
+          }
+        }
+      }
+    },
+    "stops sample playback": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stops sample playback"
+          }
+        }
+      }
+    },
+    "loading sample": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading sample"
+          }
+        }
+      }
+    },
+    "plays a sample": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plays a sample"
+          }
+        }
+      }
+    },
+    "removes this voice": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removes this voice"
+          }
+        }
+      }
+    },
+    "downloads this voice": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloads this voice"
+          }
+        }
+      }
+    },
+    "double tap for details": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Double tap for details"
+          }
+        }
+      }
+    },
+    "shows voices": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows voices"
+          }
+        }
+      }
+    },
+    "downloading_percent": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld%%"
           }
         }
       }
     }
   },
-  "version" : "1.1"
+  "version": "1.1"
 }

--- a/PiperApp/Resources/Localization/Localizable.xcstrings
+++ b/PiperApp/Resources/Localization/Localizable.xcstrings
@@ -7510,6 +7510,114 @@
             "state" : "translated",
             "value" : "Downloads this voice"
           }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ينزّل هذا الصوت"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "এই ভয়েসটি ডাউনলোড করে"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lädt diese Stimme herunter"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descarga esta voz"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Télécharge cette voix"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "यह आवाज़ डाउनलोड करता है"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letölti ezt a hangot"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengunduh suara ini"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scarica questa voce"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この音声をダウンロードします"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Downloadt deze stem"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pobiera ten głos"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hämtar denna röst"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Baixa esta voz"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu sesi indirir"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Завантажує цей голос"
+          }
+        },
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یہ آواز ڈاؤن لوڈ کرتا ہے"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载此语音"
+          }
         }
       }
     },
@@ -7520,6 +7628,114 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Shows voices"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يعرض الأصوات"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ভয়েসগুলো দেখায়"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeigt Stimmen an"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muestra voces"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Affiche les voix"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "आवाज़ें दिखाता है"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hangokat mutat"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menampilkan suara"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra le voci"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音声を表示します"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toont stemmen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokazuje głosy"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visar röster"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra vozes"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sesleri gösterir"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показує голоси"
+          }
+        },
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "آوازیں دکھاتا ہے"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示语音"
           }
         }
       }
@@ -7532,6 +7748,114 @@
             "state" : "translated",
             "value" : "Loading sample"
           }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جارٍ تحميل العينة"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "নমুনা লোড হচ্ছে"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muster wird geladen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargando muestra"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chargement de l'échantillon"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "नमूना लोड हो रहा है"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minta betöltése"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memuat sampel"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Caricamento campione in corso"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サンプルを読み込み中"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voorbeeld wordt geladen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ładowanie próbki"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laddar exempel"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carregando amostra"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Örnek yükleniyor"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Завантаження зразка"
+          }
+        },
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نمونہ لوڈ ہو رہا ہے"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在加载示例"
+          }
         }
       }
     },
@@ -7542,6 +7866,114 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Plays a sample"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يشغّل عينة"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "একটি নমুনা চালায়"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spielt ein Beispiel ab"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reproduce una muestra"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Joue un échantillon"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "नमूना चलाता है"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lejátszik egy mintát"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memutar sampel"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riproduce un campione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サンプルを再生します"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speelt een voorbeeld af"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odtwarza próbkę"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spelar upp ett exempel"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reproduz uma amostra"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bir örnek çalar"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відтворює зразок"
+          }
+        },
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نمونہ چلاتا ہے"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放示例"
           }
         }
       }
@@ -7554,6 +7986,114 @@
             "state" : "translated",
             "value" : "Stops sample playback"
           }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يوقف تشغيل العينة"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "নমুনা চালানো বন্ধ করে"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stoppt die Beispielwiedergabe"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detiene la reproducción de la muestra"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrête la lecture de l'échantillon"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "नमूना प्लेबैक रोकता है"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leállítja a minta lejátszását"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menghentikan pemutaran sampel"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interrompe la riproduzione del campione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サンプルの再生を停止します"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stopt afspelen van voorbeeld"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zatrzymuje odtwarzanie próbki"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stoppar uppspelning av exempel"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Para a reprodução da amostra"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Örnek çalmayı durdurur"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зупиняє відтворення зразка"
+          }
+        },
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نمونے کی آواز بند کرتا ہے"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止播放示例"
+          }
         }
       }
     },
@@ -7565,6 +8105,114 @@
             "state" : "translated",
             "value" : "Removes this voice"
           }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يزيل هذا الصوت"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "এই ভয়েসটি সরিয়ে দেয়"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entfernt diese Stimme"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina esta voz"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprime cette voix"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "यह आवाज़ हटाता है"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eltávolítja ezt a hangot"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menghapus suara ini"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rimuove questa voce"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この音声を削除します"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verwijdert deze stem"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuwa ten głos"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tar bort denna röst"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove esta voz"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu sesi kaldırır"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Видаляє цей голос"
+          }
+        },
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یہ آواز ہٹاتا ہے"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除此语音"
+          }
         }
       }
     },
@@ -7575,6 +8223,114 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Double tap for details"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انقر نقرًا مزدوجًا للتفاصيل"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "বিস্তারিত জানতে দুবার ট্যাপ করুন"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doppeltippen für Details"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca dos veces para ver detalles"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Double-touchez pour plus de détails"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "विवरण के लिए दो बार टैप करें"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koppintson duplán a részletekért"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ketuk dua kali untuk detail"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tocca due volte per i dettagli"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "詳細はダブルタップしてください"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dubbeltik voor details"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stuknij dwukrotnie, aby zobaczyć szczegóły"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dubbeltryck för detaljer"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toque duas vezes para detalhes"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ayrıntılar için çift dokunun"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Двічі торкніться для деталей"
+          }
+        },
+        "ur-PK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تفصیلات کے لیے دو بار ٹیپ کریں"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "轻点两下查看详情"
           }
         }
       }

--- a/PiperApp/Sources/Flows/VoicesList/Item/VoiceItemView.swift
+++ b/PiperApp/Sources/Flows/VoicesList/Item/VoiceItemView.swift
@@ -30,7 +30,7 @@ struct VoiceItemView: View {
             } label: {
                 imageView(systemName: "stop")
                     .accessibilityLabel("stop_playing")
-                    .accessibilityHint("stops sample playback")
+                    .accessibilityHint("stop_playing_hint")
             }
             .buttonStyle(.borderless)
         } else if hostModel.viewModel.isSampleLoading {
@@ -38,14 +38,14 @@ struct VoiceItemView: View {
             ProgressView()
                 .progressViewStyle(.circular)
                 .frame(width: size, height: size)
-                .accessibilityLabel("loading sample")
+                .accessibilityLabel("loading_sample")
         } else {
             Button {
                 hostModel.playSample(voice: hostModel.viewModel.voice)
             } label: {
                 imageView(systemName: "play")
                     .accessibilityLabel("play_sample")
-                    .accessibilityHint("plays a sample")
+                    .accessibilityHint("play_sample_hint")
             }
             .buttonStyle(.borderless)
         }
@@ -62,7 +62,7 @@ struct VoiceItemView: View {
                 } label: {
                     imageView(systemName: "trash")
                         .accessibilityLabel("uninstall_voice")
-                        .accessibilityHint("removes this voice")
+                        .accessibilityHint("uninstall_voice_hint")
                 }
                 .buttonStyle(.borderless)
                 .alert("uninstall_voice", isPresented: $unstallConfirmationShown) {
@@ -85,7 +85,7 @@ struct VoiceItemView: View {
                 } label: {
                     imageView(systemName: "square.and.arrow.down")
                         .accessibilityLabel("download_voice")
-                        .accessibilityHint("downloads this voice")
+                        .accessibilityHint("download_voice_hint")
                 }
                 .buttonStyle(.borderless)
             }
@@ -112,7 +112,7 @@ struct VoiceItemView: View {
             }
             .accessibilityElement(children: .combine)
             .accessibilityLabel(voiceTitle)
-            .accessibilityHint("double tap for details")
+            .accessibilityHint("voice_item_hint")
             Spacer()
             playDemo()
             download()

--- a/PiperApp/Sources/Flows/VoicesList/Item/VoiceItemView.swift
+++ b/PiperApp/Sources/Flows/VoicesList/Item/VoiceItemView.swift
@@ -18,6 +18,7 @@ struct VoiceItemView: View {
             .imageScale(.large)
             .frame(width: buttonSize, height: buttonSize)
             .foregroundColor(.accentColor)
+            .accessibilityAddTraits(.isButton)
     }
 
     @ViewBuilder
@@ -29,21 +30,24 @@ struct VoiceItemView: View {
             } label: {
                 imageView(systemName: "stop")
                     .accessibilityLabel("stop_playing")
+                    .accessibilityHint("stops sample playback")
             }
-            .buttonStyle(PlainButtonStyle())
+            .buttonStyle(.borderless)
         } else if hostModel.viewModel.isSampleLoading {
             let size = 50.0
             ProgressView()
                 .progressViewStyle(.circular)
                 .frame(width: size, height: size)
+                .accessibilityLabel("loading sample")
         } else {
             Button {
                 hostModel.playSample(voice: hostModel.viewModel.voice)
             } label: {
                 imageView(systemName: "play")
                     .accessibilityLabel("play_sample")
+                    .accessibilityHint("plays a sample")
             }
-            .buttonStyle(PlainButtonStyle())
+            .buttonStyle(.borderless)
         }
     }
 
@@ -58,8 +62,9 @@ struct VoiceItemView: View {
                 } label: {
                     imageView(systemName: "trash")
                         .accessibilityLabel("uninstall_voice")
+                        .accessibilityHint("removes this voice")
                 }
-                .buttonStyle(PlainButtonStyle())
+                .buttonStyle(.borderless)
                 .alert("uninstall_voice", isPresented: $unstallConfirmationShown) {
                     Button("uninstall_button", role: .destructive) {
                         hostModel.remove(voice: voice)
@@ -73,15 +78,16 @@ struct VoiceItemView: View {
                     .frame(width: size, height: size)
                     .accessibilityElement()
                     .accessibilityLabel("downloading")
-                    .accessibilityValue(String(localized: "voice_loading_progress_\(hostModel.viewModel.downloadProgress * 100)"))
+                    .accessibilityValue("\(Int(hostModel.viewModel.downloadProgress * 100))%")
             } else {
                 Button {
                     hostModel.download(voice: voice)
                 } label: {
                     imageView(systemName: "square.and.arrow.down")
                         .accessibilityLabel("download_voice")
+                        .accessibilityHint("downloads this voice")
                 }
-                .buttonStyle(PlainButtonStyle())
+                .buttonStyle(.borderless)
             }
         }
 
@@ -105,9 +111,12 @@ struct VoiceItemView: View {
                 }
             }
             .accessibilityElement(children: .combine)
+            .accessibilityLabel(voiceTitle)
+            .accessibilityHint("double tap for details")
             Spacer()
             playDemo()
             download()
         }
+        .accessibilityElement(children: .contain)
     }
 }

--- a/PiperApp/Sources/Flows/VoicesList/List/VoicesListView.swift
+++ b/PiperApp/Sources/Flows/VoicesList/List/VoicesListView.swift
@@ -10,7 +10,7 @@ struct VoicesListView: View {
 
     @ViewBuilder
     func voicesList(for language: String, title: String) -> some View {
-        NavigationStack {
+        Group {
             if let voices = hostModel.languages[language]?.sorted(by: { voice1, voice2 in
                 voice1.name < voice2.name
             }).filter({ voice in
@@ -20,6 +20,7 @@ struct VoicesListView: View {
                 List {
                     Text("warning_not_tested_voices")
                         .font(.title2)
+                        .accessibilityHidden(false)
                     Section {
                         ForEach(voices, id: \.key) { voice in
                             VoiceItemView(hostModel: VoiceItemHostModel(piper: hostModel.piper,
@@ -30,6 +31,7 @@ struct VoicesListView: View {
                     }
                     Text("warning_big_voice_files")
                         .font(.title2)
+                        .accessibilityHidden(false)
                 }
                 .accessibilityIdentifier("download_languages_list")
             } else {
@@ -54,6 +56,8 @@ struct VoicesListView: View {
                                 Text(title)
                                     .font(.title2)
                             }
+                            .accessibilityIdentifier("language_row_\(language)")
+                            .accessibilityHint("shows voices")
                         }
                     }
                 }

--- a/PiperApp/Sources/Flows/VoicesList/List/VoicesListView.swift
+++ b/PiperApp/Sources/Flows/VoicesList/List/VoicesListView.swift
@@ -57,7 +57,7 @@ struct VoicesListView: View {
                                     .font(.title2)
                             }
                             .accessibilityIdentifier("language_row_\(language)")
-                            .accessibilityHint("shows voices")
+                            .accessibilityHint("language_row_hint")
                         }
                     }
                 }


### PR DESCRIPTION
Fixes Miroslav Krejci Jun 18: table totally unusable with VoiceOver – skips elements, no way to pick language.

**Clean base:** this branch is from origin/main ef69a24 (previous branch mistakenly included alignment feature commits).

**Root:** VoiceItemView row had .combine on VStack without .contain on HStack. iOS 26 VoiceOver merged row, skipping play/download.

**Fix:**
- VoicesListView: remove nested NavigationStack, add row identifier + hint 'shows voices'
- VoiceItemView: row .contain (info / play / action = 3 stops), Plain -> .borderless, integer % for download, hints, .isButton trait

Visual same, a11y only.
Audit: your_files/voiceover-table-audit-2026-08-17.md
Closes feedback from miroslavkrejci1972@gmail.com