### PR TITLE
fix: resilient long utterance 1.0.13 - skip bad sentence, 2s wait (Sawyer)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "Piper",
     dependencies: [
-        .package(url: "https://github.com/IhorShevchuk/piper-objc", from: "0.2.38")
+        .package(url: "https://github.com/IhorShevchuk/piper-objc", from: "0.2.40")
     ],
     targets: []  // Tuist uses this only to resolve deps; targets are in Project.swift via .external()
 )

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "Piper",
     dependencies: [
-        .package(url: "https://github.com/IhorShevchuk/piper-objc", from: "0.2.40")
+        .package(url: "https://github.com/IhorShevchuk/piper-objc", from: "0.2.41")
     ],
     targets: []  // Tuist uses this only to resolve deps; targets are in Project.swift via .external()
 )

--- a/PiperTTS/Sources/AudioUnit/PiperTTSAudioUnit.swift
+++ b/PiperTTS/Sources/AudioUnit/PiperTTSAudioUnit.swift
@@ -22,8 +22,8 @@ public class PiperTTSAudioUnit: AVSpeechSynthesisProviderAudioUnit {
     internal var outputData = FloatRingBuffer()
     private var outputRecurseCallNumber = 0
 
-    private let outputRecurseCallNumberMax: UInt32 = 200
-    private let baseDelayMicroseconds: UInt32 = 500
+    private let outputRecurseCallNumberMax: UInt32 = 400
+    private let baseDelayMicroseconds: UInt32 = 5000
     internal let maxBufferDurationSeconds: Double = 120.0
     internal let maxSamplesCount: Int
 


### PR DESCRIPTION
Sawyer 1.0.12 still drops on long utterances:

- YouTube long post with many sentences only read 2
- iMessage long text at 55% VoiceOver rate drops mid-way (lessac)

Root causes:
1. Piper.swift aborted entire long utterance when one sentence failed (emoji/URL) via PIPER_ERR_GENERIC -> status=.error, return. Sawyer's YouTube post had one bad sentence that stopped remaining 10+ sentences.
2. AudioUnit waited only 100ms (500us*200) for next chunk, too short when Piper takes 300ms to generate next sentence on slower device.

Fixes:
- piper-objc 0.2.38->0.2.40: Piper.swift now skips failed sentence (continue/break) instead of aborting.
- PiperTTSAudioUnit: increase outputRecurseCallNumberMax 200->400, baseDelay 500us->5000us, max wait 100ms->2000ms for long utterance resilience.
- Adds regression guards in piper-objc.

Related to piper-objc PR #13.

Fixes 1.0.12 regression, targets 1.0.13.