### PR TITLE
fix(speed): preserve PT-BR sibilants – clamp max to 2.2x (1.0.13)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "Piper",
     dependencies: [
-        .package(url: "https://github.com/IhorShevchuk/piper-objc", from: "0.2.41")
+        .package(url: "https://github.com/IhorShevchuk/piper-objc", from: "0.2.42")
     ],
     targets: []  // Tuist uses this only to resolve deps; targets are in Project.swift via .external()
 )


### PR DESCRIPTION
Fixes PT-BR S loss at high speeds reported by Ricksparta (1.0.12 AppStore, 4 days ago, Brazil) and Ricardo (1.0.9).

**Root:**
speedCurve max 3.944x → length 0.25. At AV 0.8 (80%) speed 2.79 → length 0.357 drops sibilants. PT-BR voices Cadu/Jeff/Tugão lose S.

**Fix:**
- piper-objc PR #14 clamps max to 2.2x (length >=0.454)
- curve 0.70=2.0, 0.75=2.1, 0.80=2.15, 0.85=2.18, 0.90-1.00=2.2 – monotonic, preserves fast preference but keeps S
- bump piper-objc 0.2.41 -> 0.2.42

**TDD:**
Tests in piper-objc: high rates <=2.2, length >=0.45, monotonic, 80% ~0.465

**Blind user impact:** 80%+ still fast but intelligible for sibilants.

Depends on merge of piper-objc#14 + tag 0.2.42
